### PR TITLE
Update README.md and Travisfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - '12.18.3'
+git:
+  depth: false
 cache:
   npm: true
   directories:
@@ -10,6 +12,4 @@ before_script:
   - pip3 install pre-commit
 script:
   - pre-commit run -a
-# To uncomment when we have meaningful code
-# - npm install --log-level=error
-# - npm run lint
+  - npm run affected:lint -- --base=origin/master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # Müll
 
+- [Team Members](#team-members)
+- [Development Guidelines](#development-guidelines)
+- [Setting up a development environment](#setting-up-a-development-environment)
+- [Running the application](#running-the-application)
+  - [Serving the application locally for development:](#serving-the-application-locally-for-development)
+  - [Building the application for production:](#building-the-application-for-production)
+  - [Serving the production built stack locally:](#serving-the-production-built-stack-locally)
+- [Building and running the application with Docker](#building-and-running-the-application-with-docker)
+  - [Front-end](#front-end)
+  - [Back-end](#back-end)
+- [Troubleshooting](#troubleshooting)
+  - [Inonsistent/Failing Travis Builds](#inonsistentfailing-travis-builds)
+
+# Team Members
+
+Müll is brought to you by members of `Team Bug bytes`.
+
+- Ritchelle Grace Posadas, @RGPosadas (Team Lead)
+- Cristian Aldea, @TheGreatMarkus
+- Jonathan Hsu, @bit172
+- Jimmy Lau, @JimLau49
+- Cindy Lo, @cindyslittleplanet
+- Omar Sahtout, @osahtout
+- Yun Shi Lin, @ys-lin
+- Leo Jr. Silao, @leojrsilao
+- Ragith Sabapathipillai, @r-saba
+
+# Development Guidelines
+
+- We try our best to adhere to the set of rules and guidelines that we've come up as a team in order to have an efficient workflow.
+- To view, refer to our [GitHub Wiki](https://github.com/RGPosadas/Mull/wiki).
+
 # Setting up a development environment
 
 1. Install the Nx CLI:
@@ -51,3 +83,11 @@
    - `docker build -t mull-api:dev -f apps/mull-api/Dockerfile .`
 2. Run
    - `docker run -p 3333:3333 mull-api:dev`
+
+# Troubleshooting
+
+## Inonsistent/Failing Travis Builds
+
+We are now caching `npm` and `pre-commit` for faster build times. However, it is possible for the cache to be spoiled with bad data, or can simply become invalid/obsolete. This would result in inconsistent, or even failed, Travis builds compared to local builds.
+
+As a fix, try [clearing the Travis cache](https://docs.travis-ci.com/user/caching/#clearing-caches). Once cleared, re-run the builds.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -2,7 +2,10 @@
 
 This directory covers everything related to Kubernetes.
 
-## Müll Deployment
+- [Müll Deployment](#müll-deployment)
+  - [Deployment Steps](#deployment-steps)
+
+# Müll Deployment
 
 The application in both dev and prod environments are deployed through ArgoCD.
 
@@ -11,7 +14,7 @@ Pre-requisites:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - A kubernetes cluster (minikube, GKE, etc)
 
-### Deployment Steps
+## Deployment Steps
 
 1. Deploy ArgoCD
 


### PR DESCRIPTION
This PR aims to:
- Update Travis to run, at the very least, `npm run lint`
   - Please note that `npm install` is no longer needed as [Travis runs `npm ci` by default](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#npm-ci-support) due to the fact that we have a `package-lock.json`.
- Add a troubleshooting section that can be further expanded in the future
   - Please note that I also tried to add a ToC checker as a pre-commit, but the main 3 ones that I found had issues properly working as a pre-commit. Therefore, manually added ToC for README's through [github-markdown-toc ](https://github.com/ekalinin/github-markdown-toc)for now.

