### PR TITLE
TASK-3: Setup TravisCI to lint, test and build projects when relevant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ cache:
   npm: true
   directories:
     - $HOME/.cache/pre-commit
-before_script:
-  - pyenv global 3.7.1
-  - pip3 install pre-commit
 addons:
   - sonarcloud:
     organization: 'rgposadas'
     token:
       secure: $SONAR_TOKEN
+
+before_script:
+  - pyenv global 3.7.1
+  - pip3 install pre-commit
+
 script:
   - pre-commit run -a
-  - npm run affected:lint -- --base=origin/develop
-  - npm run affected:test -- --base=origin/develop --codeCoverage
-  - npm run affected:e2e -- --base=origin/develop
+  - ./scripts/ci-checks.sh
   - sonar-scanner

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "affected:libs": "nx affected:libs",
     "affected:lint": "nx affected:lint",
     "affected:test": "nx affected:test",
+    "all-projects": "nx run-many --all=true",
     "build": "nx build",
     "build-api": "nx build mull-api --prod",
     "build-ui": "nx build mull-ui --prod && npm run generate-sw",

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -1,0 +1,19 @@
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
+        # Run all checks on everything
+        npm run all-projects -- --target=lint
+        npm run all-projects -- --target=test --codeCoverage
+        npm run all-projects -- --target=e2e --headless
+    else
+        if [ "$TRAVIS_BRANCH" == "develop" ]; then
+            export BASE_BRANCH="master"
+        else
+            export BASE_BRANCH="develop"
+        fi
+        npm run affected:lint -- --base=origin/$BASE_BRANCH
+        npm run affected:test -- --base=origin/$BASE_BRANCH --codeCoverage
+        npm run affected:e2e -- --base=origin/$BASE_BRANCH
+    fi
+else
+    echo "Checks won't run on pull request builds"
+fi


### PR DESCRIPTION
NOTE: The sonar cloud coverage failure isn't related to the change I'm bringing with this pr.

This PR resolves #11 

The part of the script running lint, test and e2e checks were moved to a separate file, where the conditions described on the ticket are fulfilled. Namely:

* [x] If the current branch is master, lint, test and build all projects
* [x] If the current branch is develop, only lint, test and build affected projects, and set BASE to master (default)
* [x] If the current branch is a feature branch, only lint, test and build affected projects, and set BASE to develop (default)

You'll notice that the checks [won't run on pull request builds](https://github.com/RGPosadas/Mull/pull/56/files#diff-aa39c98ea2558b47db924f1345adb9ce1d0b5f7f544887cfcde63dbf7bcf5b1bR18), this is for a few reasons:
- We don't build pull request builds anyways:
![image](https://user-images.githubusercontent.com/23544999/97134704-81ddf280-1724-11eb-82c1-516704300a33.png)
- This extra condition will make sure that checks won't be run twice in case pull request builds are enabled again
- $TRAVIS_BRANCH [has a different value when a PR or branch build is running](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables), and handling PR builds to get the right behavior would increase the complexity of the script.