### PR TITLE
REFACTOR/TEST: let e2e tests run in both mobile and desktop view

### DIFF
--- a/apps/mull-ui-e2e/src/integration/create-event.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/create-event.spec.ts
@@ -1,85 +1,98 @@
 /// <reference types="Cypress" />
 
-describe('create-events', () => {
-  beforeEach(() => cy.visit('http://localhost:4200/create-event'));
+const frameSizes = [
+  { res: [375, 812], name: 'mobile' },
+  { res: [1920, 1080], name: 'desktop' },
+];
 
-  it('should have the correct page title', () => {
-    cy.get('.create-event-text').should('have.text', 'Create Event');
-  });
+frameSizes.forEach((frame) => {
+  describe(`US-1.1: Create Events (${frame.name} view)`, () => {
+    beforeEach(() => {
+      cy.viewport(frame.res[0], frame.res[1]);
+      cy.visit('http://localhost:4200/create-event');
+    });
 
-  it('should enter the start time', () => {
-    cy.get(':nth-child(5) > [data-testid=custom-time-input]')
-      .type('11:20')
-      .should('have.value', '11:20');
-  });
+    it('should have the correct page title', () => {
+      cy.get('.create-event-text').should('have.text', 'Create Event');
+    });
 
-  it('should enter the end time', () => {
-    cy.get(':nth-child(6) > [data-testid=custom-time-input]')
-      .type('15:20')
-      .should('have.value', '15:20');
-  });
+    it('should enter the start time', () => {
+      cy.get(':nth-child(5) > [data-testid=custom-time-input]')
+        .type('11:20')
+        .should('have.value', '11:20');
+    });
 
-  it('should type into the event title input', () => {
-    cy.get(':nth-child(7) > [data-testid=custom-text-input]')
-      .type('test title')
-      .should('have.value', 'test title');
-  });
+    it('should enter the end time', () => {
+      cy.get(':nth-child(6) > [data-testid=custom-time-input]')
+        .type('15:20')
+        .should('have.value', '15:20');
+    });
 
-  it('should select today as the start and end date', () => {
-    cy.get('.-today').click().should('have.text', new Date().getDate().toString());
-    cy.get('.-today').click().should('have.text', new Date().getDate().toString());
-  });
+    it('should type into the event title input', () => {
+      cy.get(':nth-child(7) > [data-testid=custom-text-input]')
+        .type('test title')
+        .should('have.value', 'test title');
+    });
 
-  it('should type into the event description input', () => {
-    cy.get(':nth-child(8) > [data-testid=custom-text-input]')
-      .type('test description')
-      .should('have.value', 'test description');
-  });
-  it('should type into the event location input', () => {
-    cy.get(':nth-child(9) > [data-testid=custom-text-input]')
-      .type('test location')
-      .should('have.value', 'test location');
-  });
+    it('should select today as the start and end date', () => {
+      cy.get('.-today').click().should('have.text', new Date().getDate().toString());
+      cy.get('.-today').click().should('have.text', new Date().getDate().toString());
+    });
 
-  it('should change restriction open', () => {
-    cy.get('[data-testid=pill-id-1]')
-      .click()
-      .should('have.css', 'background-color', 'rgb(39, 176, 154)');
-    cy.get('[data-testid=pill-id-2]')
-      .click()
-      .should('have.css', 'background-color', 'rgb(39, 176, 154)');
-  });
+    it('should type into the event description input', () => {
+      cy.get(':nth-child(8) > [data-testid=custom-text-input]')
+        .type('test description')
+        .should('have.value', 'test description');
+    });
+    it('should type into the event location input', () => {
+      cy.get(':nth-child(9) > [data-testid=custom-text-input]')
+        .type('test location')
+        .should('have.value', 'test location');
+    });
 
-  it('should show errors when fields are not completed', () => {
-    cy.get('.create-event-button').click();
-    cy.get(':nth-child(5) > .error-message').should('have.text', 'Start Time is required.');
-    cy.get(':nth-child(6) > .error-message').should('have.text', 'End Time is required.');
-    cy.get(':nth-child(7) > .error-message').should('have.text', 'Event Title is required.');
-    cy.get(':nth-child(8) > .error-message').should('have.text', 'Event Description is required.');
-    cy.get(':nth-child(9) > .error-message').should('have.text', 'Event Location is required.');
-  });
+    it('should change restriction open', () => {
+      cy.get('[data-testid=pill-id-1]')
+        .click()
+        .should('have.css', 'background-color', 'rgb(39, 176, 154)');
+      cy.get('[data-testid=pill-id-2]')
+        .click()
+        .should('have.css', 'background-color', 'rgb(39, 176, 154)');
+    });
 
-  it('should show a successful submission message', () => {
-    cy.get(':nth-child(5) > [data-testid=custom-time-input]').type('11:20');
+    it('should show errors when fields are not completed', () => {
+      cy.get('.create-event-button').click();
+      cy.get(':nth-child(5) > .error-message').should('have.text', 'Start Time is required.');
+      cy.get(':nth-child(6) > .error-message').should('have.text', 'End Time is required.');
+      cy.get(':nth-child(7) > .error-message').should('have.text', 'Event Title is required.');
+      cy.get(':nth-child(8) > .error-message').should(
+        'have.text',
+        'Event Description is required.'
+      );
+      cy.get(':nth-child(9) > .error-message').should('have.text', 'Event Location is required.');
+    });
 
-    cy.get(':nth-child(6) > [data-testid=custom-time-input]').type('15:20');
+    it('should show a successful submission message', () => {
+      cy.get(':nth-child(5) > [data-testid=custom-time-input]').type('11:20');
 
-    cy.get(':nth-child(7) > [data-testid=custom-text-input]').type('test title');
+      cy.get(':nth-child(6) > [data-testid=custom-time-input]').type('15:20');
 
-    cy.get('.-today').click();
-    cy.get('.-today').click();
+      cy.get(':nth-child(7) > [data-testid=custom-text-input]').type('test title');
 
-    cy.get(':nth-child(8) > [data-testid=custom-text-input]').type('test description');
+      cy.get('.-today').click();
+      cy.get('.-today').click();
 
-    cy.get(':nth-child(9) > [data-testid=custom-text-input]').type('test location');
+      cy.get(':nth-child(8) > [data-testid=custom-text-input]').type('test description');
 
-    cy.get('[data-testid=pill-id-1]').click();
-    cy.get('.create-event-button').click();
+      cy.get(':nth-child(9) > [data-testid=custom-text-input]').type('test location');
 
-    cy.get('.Toastify__toast.Toastify__toast--success', { timeout: 1000 }).should(
-      'have.css',
-      'background-color',
-      'rgb(39, 176, 154)'
-    );
+      cy.get('[data-testid=pill-id-1]').click();
+      cy.get('.create-event-button').click();
+
+      cy.get('.Toastify__toast.Toastify__toast--success', { timeout: 1000 }).should(
+        'have.css',
+        'background-color',
+        'rgb(39, 176, 154)'
+      );
+    });
   });
 });

--- a/apps/mull-ui/src/app/components/navigation-bar/navigation-bar.scss
+++ b/apps/mull-ui/src/app/components/navigation-bar/navigation-bar.scss
@@ -13,7 +13,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-around;
-  padding: 0.7em 0;
+  padding: 0.7em 0 1.5em;
 
   box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.25);
 }
@@ -22,7 +22,6 @@
   fill: $inactive-button-color;
   width: 2.2em;
   height: 2.2em;
-  margin-bottom: 1.15em;
 
   @include nav-button;
 }


### PR DESCRIPTION
This PR aims to have the E2E tests run on both mobile and desktop view. It was previously running at a random window size, and since our app is a PWA, both views must be covered.

You may see how our sole E2E test runs [here](https://github.com/RGPosadas/Mull/wiki/Acceptance-Test-GIFs).