### PR TITLE
FIX: Remove unused proxy conf file

### DIFF
--- a/apps/mull-ui/proxy.conf.json
+++ b/apps/mull-ui/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "/api": {
-    "target": "http://localhost:3333",
-    "secure": false
-  }
-}


### PR DESCRIPTION
This file created a proxy for the backend, allowing us to access the backend through localhost:4200/api or localhost:4200/graphql. It was generated when the project was created but is no longer used