### PR TITLE
HOTFIX: Remove proxyConfig option for mull-ui serve

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -56,8 +56,7 @@
         "serve": {
           "builder": "@nrwl/web:dev-server",
           "options": {
-            "buildTarget": "mull-ui:build",
-            "proxyConfig": "apps/mull-ui/proxy.conf.json"
+            "buildTarget": "mull-ui:build"
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
I'm very sorry everyone for this oversight, but the proxy config file deleted in #71 was referenced in the workspace.json, and serving the front-end doesn't work unless that reference is removed.

Error:
![image](https://user-images.githubusercontent.com/23544999/98860052-19d02180-2431-11eb-8294-41024d7c9e8c.png)
