### PR TITLE
TASK-22: Back button

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -3,8 +3,7 @@ import { ToastContainer, toast } from 'react-toastify';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import CreateEventPage from './pages/create-event/create-event';
-import NavigationBar from './components/navigation-bar/navigation-bar';
-import Header from './components/header/header';
+import { NavigationBar, Header } from './components';
 import { ROUTES } from '../constants';
 
 import 'react-toastify/dist/ReactToastify.min.css';

--- a/apps/mull-ui/src/app/components/header/header.spec.tsx
+++ b/apps/mull-ui/src/app/components/header/header.spec.tsx
@@ -19,6 +19,8 @@ describe('Header', () => {
         <Header />
       </Router>
     );
+
+    expect(baseElement).toBeTruthy();
   });
 
   it('button associated with current should be active ', () => {

--- a/apps/mull-ui/src/app/components/index.ts
+++ b/apps/mull-ui/src/app/components/index.ts
@@ -1,0 +1,3 @@
+export * from './header/header';
+export * from './mull-back-button/mull-back-button';
+export * from './navigation-bar/navigation-bar';

--- a/apps/mull-ui/src/app/components/mull-back-button/__snapshots__/mull-back-button.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/mull-back-button/__snapshots__/mull-back-button.spec.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MullBackButton should match snapshot 1`] = `
+Array [
+  " ",
+  <button
+    className="mull-back-button undefined"
+    data-testid="mull-back-button"
+    onClick={[Function]}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-left fa-w-10 mull-back-button-icon"
+      data-icon="chevron-left"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    <div
+      className="mull-back-button-text"
+    >
+      Back Button
+    </div>
+  </button>,
+  " ",
+]
+`;

--- a/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.scss
+++ b/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.scss
@@ -1,0 +1,20 @@
+@import 'variables';
+
+.mull-back-button {
+  outline: none;
+  background-color: transparent;
+
+  .mull-back-button-icon {
+    display: inline;
+    vertical-align: middle;
+    color: $primary-color;
+    height: 1.5rem !important;
+    width: 1.5rem !important;
+    font-weight: lighter;
+  }
+  .mull-back-button-text {
+    display: inline;
+    vertical-align: middle;
+    color: $primary-color;
+  }
+}

--- a/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.spec.tsx
+++ b/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import renderer from 'react-test-renderer';
+import ReactTestUtils from 'react-dom/test-utils';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+
+import MullBackButton from './mull-back-button';
+
+describe('MullBackButton', () => {
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+    const { baseElement } = render(
+      <Router history={history}>
+        <MullBackButton history={history} />
+      </Router>
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match snapshot', () => {
+    const history = createMemoryHistory();
+    const tree = renderer
+      .create(
+        <Router history={history}>
+          {' '}
+          <MullBackButton history={history}>Back Button</MullBackButton>{' '}
+        </Router>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should go to the previous page on click', () => {
+    const history = createMemoryHistory();
+    const dom = render(<MullBackButton history={history} />);
+
+    history.push('/path1');
+    history.push('/path2');
+
+    const button = dom.getByTestId('mull-back-button');
+
+    ReactTestUtils.Simulate.click(button);
+
+    expect(history.location.pathname).toBe('/path1');
+  });
+
+  it('should run the provided function on click', () => {
+    const mockCallback = jest.fn(() => {
+      /* Do nothing */
+    });
+    const history = createMemoryHistory();
+    const dom = render(<MullBackButton onClick={mockCallback} history={history} />);
+    const button = dom.getByTestId('mull-back-button');
+
+    ReactTestUtils.Simulate.click(button);
+
+    expect(mockCallback.mock.calls.length).toBe(1);
+  });
+});

--- a/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.tsx
+++ b/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.tsx
@@ -1,0 +1,39 @@
+import React, { ReactNode } from 'react';
+import { History } from 'history';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+
+import './mull-back-button.scss';
+
+export interface MullBackButtonProps {
+  children?: ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  className?: string;
+  style?: React.CSSProperties;
+  history: History;
+}
+
+export const MullBackButton = ({
+  history,
+  children = null,
+  onClick = () => {
+    history.goBack();
+  },
+  className,
+  style,
+}: MullBackButtonProps) => {
+  return (
+    <button
+      data-testid="mull-back-button"
+      className={`mull-back-button ${className}`}
+      onClick={onClick}
+      style={style}
+    >
+      <FontAwesomeIcon icon={faChevronLeft} className="mull-back-button-icon" />
+      <div className="mull-back-button-text">{children}</div>
+    </button>
+  );
+};
+
+export default MullBackButton;

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -18,6 +18,8 @@ import {
   faImages,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { History } from 'history';
+
 import './create-event.scss';
 
 export interface CreateEventProps {
@@ -37,7 +39,7 @@ const CREATE_EVENT = gql`
  * This component renders the create event page
  * @param {History} history
  */
-const CreateEventPage = ({ history }) => {
+const CreateEventPage = ({ history }: CreateEventProps) => {
   // Reference Id for the toast
   const toastId = useRef(null);
   // GraphQL mutation hook to create events

--- a/libs/ui-lib/src/lib/custom-text-input/custom-text-input.spec.tsx
+++ b/libs/ui-lib/src/lib/custom-text-input/custom-text-input.spec.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import CustomTextInput, { CustomTextInputProps } from './custom-text-input';
 

--- a/libs/ui-lib/src/lib/custom-time-picker/custom-time-picker.spec.tsx
+++ b/libs/ui-lib/src/lib/custom-time-picker/custom-time-picker.spec.tsx
@@ -20,13 +20,6 @@ describe('CustomTimePicker', () => {
     expect(baseElement).toBeTruthy();
   });
 
-  it('should render successfully', () => {
-    const props = mockCustomTimePickerProps();
-    props.hasErrors = false;
-    const { baseElement } = render(<CustomTimePicker {...props} />);
-    expect(baseElement).toBeTruthy();
-  });
-
   it('should match snapshot', () => {
     const props = mockCustomTimePickerProps();
     const tree = renderer.create(<CustomTimePicker {...props} />).toJSON();

--- a/libs/ui-lib/src/lib/styles/styles.scss
+++ b/libs/ui-lib/src/lib/styles/styles.scss
@@ -25,3 +25,15 @@
     margin: 0 1em;
   }
 }
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  filter: brightness(110%);
+}
+
+button:active {
+  filter: brightness(125%);
+}


### PR DESCRIPTION
This PR addressed  #78

Notes:
* 9f4abc0 adds a temporary button in create event page so people can test as part of this pr, will be removed before merging.
* e2e tests are failing, but that is normal since I modified the create event page to test the back button. e2e tests will work again when test back button is removed from create event page

To see and test the button:
* Go to a page such as the Create Event page: `apps/mull-ui/src/app/pages/create-event/create-event.tsx`
* import the button `import { MullBackButton } from '../../components';`
* Add it somewhere in the page: `<MullBackButton history={history}>Back Button!!</MullBackButton>`