### PR TITLE
FIX: Remove test error messages for ui-lib

### DIFF
--- a/libs/ui-lib/src/lib/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
+++ b/libs/ui-lib/src/lib/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
@@ -15,38 +15,7 @@ exports[`CustomTextInput should match snapshot 1`] = `
     data-testid="custom-text-input"
     id="text"
     name="text"
-    onChange={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            SyntheticEvent {
-              "_dispatchInstances": null,
-              "_dispatchListeners": null,
-              "_targetInst": null,
-              "bubbles": null,
-              "cancelable": null,
-              "currentTarget": [Function],
-              "defaultPrevented": null,
-              "dispatchConfig": null,
-              "eventPhase": null,
-              "isDefaultPrevented": [Function],
-              "isPropagationStopped": [Function],
-              "isTrusted": null,
-              "nativeEvent": null,
-              "target": null,
-              "timeStamp": [Function],
-              "type": null,
-            },
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      }
-    }
+    onChange={[MockFunction]}
     type="text"
     value=""
   />

--- a/libs/ui-lib/src/lib/custom-text-input/custom-text-input.spec.tsx
+++ b/libs/ui-lib/src/lib/custom-text-input/custom-text-input.spec.tsx
@@ -25,11 +25,11 @@ describe('CustomTextInput', () => {
   it('should have the correct text input', () => {
     const props = mockCustomTextInputProps();
     const inputText = 'Denial anger bartering depression acceptance';
-    const utils = render(<CustomTextInput {...props} />);
-    const input = utils.getByTestId('custom-text-input');
-    fireEvent.change(input, { target: { value: inputText } });
     props.value = inputText;
-    utils.rerender(<CustomTextInput {...props} />);
+
+    const utils = render(<CustomTextInput {...props} />);
+
+    const input = utils.getByTestId('custom-text-input') as HTMLInputElement;
     expect(input.value).toBe(inputText);
   });
 


### PR DESCRIPTION
This Fix aims to fix the error messages we're getting on travis about synthetic events
`     Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the property bubbles on a released/nullified synthetic event. This is set to null. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.`