### PR TITLE
BUG-7: SwipeableRoutes Not working

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -50,7 +50,7 @@ export const App = () => {
               <Route path={ROUTES.DISCOVER} component={() => <div>DISCOVER!</div>} />
               <Route path={ROUTES.UPCOMING} component={() => <div>UPCOMING!</div>} />
               <Route path={ROUTES.MY_EVENTS} component={() => <div>MY_EVENTS!</div>} />
-              <Route path={ROUTES.HOME} render={() => <Redirect to={ROUTES.DISCOVER} />} />
+              <Route exact path={ROUTES.HOME} render={() => <Redirect to={ROUTES.DISCOVER} />} />
             </SwipeableRoutes>
           </div>
         </Route>


### PR DESCRIPTION
Fix for #106 

Added an exact match for the `home` route so that it is not matched on routes like `/home/discover`. 