### PR TITLE
BUG-8: Fix Flaky Test

### DIFF
--- a/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
@@ -99,7 +99,7 @@ describe('CreateEvent', () => {
 
     let calendarDate = utils.container.querySelector('span[class="nice-dates-day -today"]');
     fireEvent.click(calendarDate);
-    calendarDate = utils.container.querySelector('span[class="nice-dates-day"]');
+    calendarDate = utils.container.querySelector('span[class="nice-dates-day -outside"]');
     fireEvent.click(calendarDate);
     let input = utils.getByLabelText('Start Time');
     fireEvent.change(input, { target: { value: '04:20' } });


### PR DESCRIPTION
closes #107

Instead of querying span[class="nice-dates-day"], which might not exist, the test now queries the first span[class="nice-dates-day -outside"], which corresponds to the first day which is outside the current month, which will always be on the calendar.

To test that the bug doesn't occur anymore, remember that you can change your os clock, which will affect the test