### PR TITLE
TASK-21: Show events as a list front end

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -14,6 +14,7 @@ import { ROUTES } from '../constants';
 import 'react-toastify/dist/ReactToastify.min.css';
 import './app.scss';
 import { dummyEvent } from '../constants';
+import DiscoverPage from './pages/discover/discover';
 
 /**
  * Main component of the application
@@ -47,7 +48,7 @@ export const App = () => {
           <div className="page-container">
             <SubNavigationBar />
             <SwipeableRoutes>
-              <Route path={ROUTES.DISCOVER} component={() => <div>DISCOVER!</div>} />
+              <Route path={ROUTES.DISCOVER} component={DiscoverPage} />
               <Route path={ROUTES.UPCOMING} component={() => <div>UPCOMING!</div>} />
               <Route path={ROUTES.MY_EVENTS} component={() => <div>MY_EVENTS!</div>} />
               <Route exact path={ROUTES.HOME} render={() => <Redirect to={ROUTES.DISCOVER} />} />

--- a/apps/mull-ui/src/app/components/event-card/event-card.scss
+++ b/apps/mull-ui/src/app/components/event-card/event-card.scss
@@ -3,7 +3,6 @@
 .event-card-container {
   position: relative;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.25);
-  margin-bottom: 2rem;
 }
 
 .event-card-container,

--- a/apps/mull-ui/src/app/components/event-card/event-card.scss
+++ b/apps/mull-ui/src/app/components/event-card/event-card.scss
@@ -3,6 +3,7 @@
 .event-card-container {
   position: relative;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.25);
+  margin-bottom: 2rem;
 }
 
 .event-card-container,

--- a/apps/mull-ui/src/app/pages/discover/discover.scss
+++ b/apps/mull-ui/src/app/pages/discover/discover.scss
@@ -1,8 +1,6 @@
-@import '../../../variables.scss';
-
 .discover-page-container {
   margin-top: 1.5rem;
   .event-card-container:last-child {
-    margin-bottom: 1rem !important;
+    margin-bottom: 1rem;
   }
 }

--- a/apps/mull-ui/src/app/pages/discover/discover.scss
+++ b/apps/mull-ui/src/app/pages/discover/discover.scss
@@ -1,6 +1,9 @@
 .discover-page-container {
   margin-top: 1.5rem;
-  .event-card-container:last-child {
-    margin-bottom: 1rem;
+  .event-card-container {
+    margin-bottom: 2rem;
+    &:last-child {
+      margin-bottom: 1rem;
+    }
   }
 }

--- a/apps/mull-ui/src/app/pages/discover/discover.scss
+++ b/apps/mull-ui/src/app/pages/discover/discover.scss
@@ -1,0 +1,8 @@
+@import '../../../variables.scss';
+
+.discover-page-container {
+  margin-top: 1.5rem;
+  .event-card-container:last-child {
+    margin-bottom: 1rem !important;
+  }
+}

--- a/apps/mull-ui/src/app/pages/discover/discover.spec.tsx
+++ b/apps/mull-ui/src/app/pages/discover/discover.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import '@testing-library/jest-dom';
+import DiscoverPage from './discover';
+import { ROUTES } from '../../../constants';
+
+describe('discoverPage', () => {
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+    history.push(ROUTES.DISCOVER);
+
+    const { baseElement } = render(
+      <MockedProvider>
+        <Router history={history}>
+          <DiscoverPage />
+        </Router>
+      </MockedProvider>
+    );
+    expect(baseElement).toBeTruthy();
+  });
+  it('should render eventCards within the discover page', () => {
+    const history = createMemoryHistory();
+    history.push(ROUTES.DISCOVER);
+
+    const utils = render(
+      <MockedProvider>
+        <Router history={history}>
+          <DiscoverPage />
+        </Router>
+      </MockedProvider>
+    );
+    const eventCards = utils.container.querySelector('.event-card-container');
+    expect(eventCards).toBeTruthy();
+  });
+});

--- a/apps/mull-ui/src/app/pages/discover/discover.tsx
+++ b/apps/mull-ui/src/app/pages/discover/discover.tsx
@@ -1,0 +1,16 @@
+import { IEvent } from '@mull/types';
+import React from 'react';
+import { EventCard } from '../../components';
+import { dummyEvent } from 'apps/mull-ui/src/constants';
+
+import './discover.scss';
+
+export const DiscoverPage = () => {
+  const events: [IEvent] = Array(5).fill(dummyEvent) as [IEvent]; // will be replaced with a query call
+  const mapped = events.map((event, index) => (
+    <EventCard key={index} event={event} style={{ marginBottom: '2rem' }} />
+  ));
+  return <div className="discover-page-container">{mapped}</div>;
+};
+
+export default DiscoverPage;

--- a/apps/mull-ui/src/app/pages/discover/discover.tsx
+++ b/apps/mull-ui/src/app/pages/discover/discover.tsx
@@ -7,10 +7,8 @@ import './discover.scss';
 
 export const DiscoverPage = () => {
   const events: [IEvent] = Array(5).fill(dummyEvent) as [IEvent]; // will be replaced with a query call
-  const mapped = events.map((event, index) => (
-    <EventCard key={index} event={event} />
-  ));
-  return <div className="discover-page-container">{mapped}</div>;
+  const eventCards = events.map((event, index) => <EventCard key={index} event={event} />);
+  return <div className="discover-page-container">{eventCards}</div>;
 };
 
 export default DiscoverPage;

--- a/apps/mull-ui/src/app/pages/discover/discover.tsx
+++ b/apps/mull-ui/src/app/pages/discover/discover.tsx
@@ -8,7 +8,7 @@ import './discover.scss';
 export const DiscoverPage = () => {
   const events: [IEvent] = Array(5).fill(dummyEvent) as [IEvent]; // will be replaced with a query call
   const mapped = events.map((event, index) => (
-    <EventCard key={index} event={event} style={{ marginBottom: '2rem' }} />
+    <EventCard key={index} event={event} />
   ));
   return <div className="discover-page-container">{mapped}</div>;
 };


### PR DESCRIPTION
closes #76 - The discover page now shows a list of events. 

**Notes**
The list of events is stored in a variable for this PR. It will come from a graphql query in #65 