### PR TITLE
FIX: Add neat workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "editor.formatOnSave": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/apps/mull-api/src/app/app.controller.spec.ts
+++ b/apps/mull-api/src/app/app.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 

--- a/apps/mull-api/src/app/app.controller.ts
+++ b/apps/mull-api/src/app/app.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get } from '@nestjs/common';
-
 import { AppService } from './app.service';
 
 @Controller()

--- a/apps/mull-api/src/app/app.module.ts
+++ b/apps/mull-api/src/app/app.module.ts
@@ -1,23 +1,20 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { GraphQLModule } from '@nestjs/graphql';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { SessionModule } from 'nestjs-session';
-import { Connection } from 'typeorm';
 import { join } from 'path';
-
+import { Connection } from 'typeorm';
+import { environment } from '../environments/environment';
 // Controllers
 import { AppController } from './app.controller';
-
 // Services
 import { AppService } from './app.service';
-
+import { AuthModule } from './auth/auth.module';
+import { EntitiesModule } from './entities';
+import { EventModule } from './event/event.module';
+import { MediaModule } from './media/media.module';
 // Modules
 import { UserModule } from './user';
-import { EventModule } from './event/event.module';
-import { EntitiesModule } from './entities';
-import { MediaModule } from './media/media.module';
-import { environment } from '../environments/environment';
-import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [

--- a/apps/mull-api/src/app/app.service.spec.ts
+++ b/apps/mull-api/src/app/app.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test } from '@nestjs/testing';
-
 import { AppService } from './app.service';
 
 describe('AppService', () => {

--- a/apps/mull-api/src/app/app.service.ts
+++ b/apps/mull-api/src/app/app.service.ts
@@ -1,7 +1,6 @@
+import { Message } from '@mull/types';
 import { Injectable } from '@nestjs/common';
 import { environment } from '../environments/environment';
-
-import { Message } from '@mull/types';
 
 @Injectable()
 export class AppService {

--- a/apps/mull-api/src/app/auth/auth.controller.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.ts
@@ -1,10 +1,10 @@
 import { Controller, Get, Post, Req, Res, UseGuards } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { Request, Response } from 'express';
-import { AuthGuard } from '@nestjs/passport';
 import { JwtService } from '@nestjs/jwt';
+import { AuthGuard } from '@nestjs/passport';
+import { Request, Response } from 'express';
 import { environment } from '../../environments/environment';
 import { UserService } from '../user';
+import { AuthService } from './auth.service';
 
 @Controller('auth')
 export class AuthController {

--- a/apps/mull-api/src/app/auth/auth.module.ts
+++ b/apps/mull-api/src/app/auth/auth.module.ts
@@ -1,14 +1,12 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
-import { UserModule } from '../user';
 import { PassportModule } from '@nestjs/passport';
-import { AuthService } from './auth.service';
+import { UserModule } from '../user';
 import { AuthController } from './auth.controller';
-
 import { AuthResolver } from './auth.resolver';
-
-import { GoogleStrategy } from './strategies/google.strategy';
+import { AuthService } from './auth.service';
 import { FacebookStrategy } from './strategies/facebook.strategy';
+import { GoogleStrategy } from './strategies/google.strategy';
 import { TwitterStrategy } from './strategies/twitter.strategy';
 
 @Module({

--- a/apps/mull-api/src/app/auth/auth.resolver.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.resolver.spec.ts
@@ -1,6 +1,6 @@
 import { GqlContext } from '@mull/types';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Response, Request } from 'express';
+import { Request, Response } from 'express';
 import { AuthResolver, LoginResult } from './auth.resolver';
 import { AuthService } from './auth.service';
 import { LoginInput } from './inputs/auth.input';

--- a/apps/mull-api/src/app/auth/auth.resolver.ts
+++ b/apps/mull-api/src/app/auth/auth.resolver.ts
@@ -1,9 +1,7 @@
-import { Args, Context, Field, Mutation, ObjectType, Resolver } from '@nestjs/graphql';
-
-import { AuthService } from './auth.service';
-
-import { LoginInput } from './inputs/auth.input';
 import { GqlContext } from '@mull/types';
+import { Args, Context, Field, Mutation, ObjectType, Resolver } from '@nestjs/graphql';
+import { AuthService } from './auth.service';
+import { LoginInput } from './inputs/auth.input';
 
 @ObjectType()
 export class LoginResult {

--- a/apps/mull-api/src/app/auth/auth.service.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.service.spec.ts
@@ -1,13 +1,13 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
-import { mockAllUsers } from '../user/user.mockdata';
-import { UserService } from '../user/user.service';
-import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
 import { User } from '../entities';
 import { CreateUserInput } from '../user/inputs/user.input';
-import { JwtService } from '@nestjs/jwt';
+import { mockAllUsers } from '../user/user.mockdata';
+import { UserService } from '../user/user.service';
 import { MockType } from '../user/user.service.spec';
-import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
 
 const mockUserService = () => ({
   findUnique: jest.fn(),

--- a/apps/mull-api/src/app/auth/auth.service.ts
+++ b/apps/mull-api/src/app/auth/auth.service.ts
@@ -1,10 +1,9 @@
+import { RegistrationMethod } from '@mull/types';
 import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { compare } from 'bcrypt';
 import { Request, Response } from 'express';
-
 import { environment } from '../../environments/environment';
-import { RegistrationMethod } from '@mull/types';
 import { User } from '../entities';
 import { CreateUserInput } from '../user/inputs/user.input';
 import { UserService } from '../user/user.service';

--- a/apps/mull-api/src/app/auth/strategies/facebook.strategy.ts
+++ b/apps/mull-api/src/app/auth/strategies/facebook.strategy.ts
@@ -1,10 +1,10 @@
+import { RegistrationMethod } from '@mull/types';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy, StrategyOption } from 'passport-facebook';
 import { environment } from '../../../environments/environment';
-import { Injectable } from '@nestjs/common';
 import { User } from '../../entities';
 import { AuthService } from './../auth.service';
-import { RegistrationMethod } from '@mull/types';
 
 @Injectable()
 export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {

--- a/apps/mull-api/src/app/auth/strategies/google.strategy.ts
+++ b/apps/mull-api/src/app/auth/strategies/google.strategy.ts
@@ -1,10 +1,10 @@
+import { RegistrationMethod } from '@mull/types';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy, StrategyOptions, VerifyCallback } from 'passport-google-oauth20';
 import { environment } from '../../../environments/environment';
-import { Injectable } from '@nestjs/common';
-import { AuthService } from './../auth.service';
 import { User } from '../../entities';
-import { RegistrationMethod } from '@mull/types';
+import { AuthService } from './../auth.service';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {

--- a/apps/mull-api/src/app/auth/strategies/twitter.strategy.ts
+++ b/apps/mull-api/src/app/auth/strategies/twitter.strategy.ts
@@ -1,10 +1,10 @@
+import { RegistrationMethod } from '@mull/types';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { IStrategyOption, Profile, Strategy } from 'passport-twitter';
 import { environment } from '../../../environments/environment';
-import { Injectable } from '@nestjs/common';
 import { User } from '../../entities';
 import { AuthService } from './../auth.service';
-import { RegistrationMethod } from '@mull/types';
 
 @Injectable()
 export class TwitterStrategy extends PassportStrategy(Strategy, 'twitter') {

--- a/apps/mull-api/src/app/entities/channel.entity.ts
+++ b/apps/mull-api/src/app/entities/channel.entity.ts
@@ -1,11 +1,11 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
-  ManyToOne,
-  ManyToMany,
-  OneToMany,
+  Entity,
   JoinTable,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Event } from './event.entity';
 import { Post } from './post.entity';

--- a/apps/mull-api/src/app/entities/entities.module.ts
+++ b/apps/mull-api/src/app/entities/entities.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-
 // Entities
 import { Channel } from './channel.entity';
 import { Event } from './event.entity';

--- a/apps/mull-api/src/app/entities/event.entity.ts
+++ b/apps/mull-api/src/app/entities/event.entity.ts
@@ -1,20 +1,20 @@
-import {
-  Entity,
-  Column,
-  PrimaryGeneratedColumn,
-  OneToOne,
-  JoinColumn,
-  OneToMany,
-  ManyToOne,
-  ManyToMany,
-  JoinTable,
-} from 'typeorm';
-import { Media } from './media.entity';
-import { Channel } from './channel.entity';
-import { User } from './user.entity';
-import { Location } from './location.entity';
-import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { EventRestriction, IEvent } from '@mull/types';
+import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Channel } from './channel.entity';
+import { Location } from './location.entity';
+import { Media } from './media.entity';
+import { User } from './user.entity';
 
 registerEnumType(EventRestriction, {
   name: 'EventRestriction',

--- a/apps/mull-api/src/app/entities/index.ts
+++ b/apps/mull-api/src/app/entities/index.ts
@@ -1,9 +1,8 @@
-export * from './user.entity';
-export * from './media.entity';
-export * from './event.entity';
 export * from './channel.entity';
-export * from './post.entity';
-export * from './post-reaction.entity';
-export * from './location.entity';
-
 export * from './entities.module';
+export * from './event.entity';
+export * from './location.entity';
+export * from './media.entity';
+export * from './post-reaction.entity';
+export * from './post.entity';
+export * from './user.entity';

--- a/apps/mull-api/src/app/entities/location.entity.ts
+++ b/apps/mull-api/src/app/entities/location.entity.ts
@@ -1,7 +1,6 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
-import { Event } from './event.entity';
-
 import { ILocation } from '@mull/types';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Event } from './event.entity';
 
 @Entity()
 export class Location implements ILocation {

--- a/apps/mull-api/src/app/entities/media.entity.ts
+++ b/apps/mull-api/src/app/entities/media.entity.ts
@@ -1,6 +1,6 @@
 import { IMedia } from '@mull/types';
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Post } from './post.entity';
 
 @Entity()

--- a/apps/mull-api/src/app/entities/post-reaction.entity.ts
+++ b/apps/mull-api/src/app/entities/post-reaction.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Post } from './post.entity';
 import { User } from './user.entity';
 

--- a/apps/mull-api/src/app/entities/post.entity.ts
+++ b/apps/mull-api/src/app/entities/post.entity.ts
@@ -1,16 +1,16 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
+  Entity,
   JoinColumn,
-  OneToOne,
-  OneToMany,
   ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Channel } from './channel.entity';
-import { User } from './user.entity';
-import { PostReaction } from './post-reaction.entity';
 import { Media } from './media.entity';
+import { PostReaction } from './post-reaction.entity';
+import { User } from './user.entity';
 
 @Entity()
 export class Post {

--- a/apps/mull-api/src/app/entities/user.entity.ts
+++ b/apps/mull-api/src/app/entities/user.entity.ts
@@ -1,18 +1,18 @@
-import {
-  Entity,
-  Column,
-  PrimaryGeneratedColumn,
-  OneToOne,
-  ManyToMany,
-  JoinTable,
-  JoinColumn,
-  OneToMany,
-} from 'typeorm';
-import { Media } from './media.entity';
-import { Event } from './event.entity';
-import { PostReaction } from './post-reaction.entity';
-import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { IUser, RegistrationMethod } from '@mull/types';
+import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Event } from './event.entity';
+import { Media } from './media.entity';
+import { PostReaction } from './post-reaction.entity';
 
 registerEnumType(RegistrationMethod, {
   name: 'RegistrationMethod',

--- a/apps/mull-api/src/app/event/event.mockdata.ts
+++ b/apps/mull-api/src/app/event/event.mockdata.ts
@@ -1,6 +1,6 @@
-import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 import { Event } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
+import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 
 const userA = mockAllUsers[0]; // id: 1
 const userB = mockAllUsers[1]; // id: 7

--- a/apps/mull-api/src/app/event/event.module.ts
+++ b/apps/mull-api/src/app/event/event.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
-import { EventService } from './event.service';
-import { EventResolver } from './event.resolver';
-import { Event } from '../entities';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from '../entities';
+import { EventResolver } from './event.resolver';
+import { EventService } from './event.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Event])],

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { User } from '../entities';
+import { mockAllUsers } from '../user/user.mockdata';
+import { mockAllEvents, mockPartialEvent } from './event.mockdata';
 import { EventResolver } from './event.resolver';
 import { EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
-import { mockPartialEvent, mockAllEvents } from './event.mockdata';
-import { User } from '../entities';
-import { mockAllUsers } from '../user/user.mockdata';
 
 const mockEventService = () => ({
   create: jest.fn((mockEventData: CreateEventInput) => ({ ...mockEventData })),

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { EventService } from './event.service';
-import { Event } from '../entities';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { CreateEventInput } from './inputs/event.input';
-import { mockAllEvents, mockPartialEvent } from './event.mockdata';
 import { Repository } from 'typeorm';
+import { Event } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
+import { mockAllEvents, mockPartialEvent } from './event.mockdata';
+import { EventService } from './event.service';
+import { CreateEventInput } from './inputs/event.input';
 
 export type MockType<T> = {
   [P in keyof T]: jest.Mock<{}>;

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -1,9 +1,9 @@
+import { EventRestriction } from '@mull/types';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, Repository } from 'typeorm';
 import { Event, User } from '../entities';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
-import { EventRestriction } from '@mull/types';
 
 @Injectable()
 export class EventService {

--- a/apps/mull-api/src/app/media/inputs/media.input.ts
+++ b/apps/mull-api/src/app/media/inputs/media.input.ts
@@ -1,5 +1,5 @@
-import { Media } from '../../entities';
 import { Field, InputType } from '@nestjs/graphql';
+import { Media } from '../../entities';
 
 @InputType()
 export class MediaInput implements Partial<Media> {

--- a/apps/mull-api/src/app/media/media.module.ts
+++ b/apps/mull-api/src/app/media/media.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
+import { EntitiesModule } from '../entities';
 import { MediaResolver } from './media.resolver';
 import { MediaService } from './media.service';
-import { EntitiesModule } from '../entities';
 
 @Module({
   imports: [EntitiesModule],

--- a/apps/mull-api/src/app/media/media.resolver.spec.ts
+++ b/apps/mull-api/src/app/media/media.resolver.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { createWriteStream, renameSync, unlinkSync } from 'fs';
+import { FileUpload } from 'graphql-upload';
+import { join } from 'path';
 import { Media } from '../entities';
 import { mockFile, mockInvalidFile, mockMedia } from './media.mockdata';
 import { MediaResolver } from './media.resolver';
 import { MediaService } from './media.service';
-import { FileUpload } from 'graphql-upload';
-import { createWriteStream, renameSync, unlinkSync } from 'fs';
-import { join } from 'path';
 
 const mockMediaService = () => ({
   create: jest.fn((mockMimeType: string) => {

--- a/apps/mull-api/src/app/media/media.resolver.ts
+++ b/apps/mull-api/src/app/media/media.resolver.ts
@@ -1,8 +1,8 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql';
-import { FileUpload } from 'graphql-upload';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { GraphQLUpload } from 'apollo-server-express';
-import { MediaService } from './media.service';
+import { FileUpload } from 'graphql-upload';
 import { Media } from '../entities';
+import { MediaService } from './media.service';
 
 @Resolver('Media')
 export class MediaResolver {

--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Media } from '../entities';
-import { MediaService } from './media.service';
-import { mockFile, mockInvalidFile } from './media.mockdata';
 import { unlinkSync } from 'fs';
+import { Media } from '../entities';
+import { mockFile, mockInvalidFile } from './media.mockdata';
+import { MediaService } from './media.service';
 
 const mockMediaRepository = () => ({
   create: jest.fn((mockMimeType: string) => {

--- a/apps/mull-api/src/app/user/user.mockdata.ts
+++ b/apps/mull-api/src/app/user/user.mockdata.ts
@@ -1,6 +1,6 @@
-import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
-import { User } from '../entities';
 import { RegistrationMethod } from '@mull/types';
+import { User } from '../entities';
+import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
 
 export const mockPartialUser: CreateUserInput | UpdateUserInput = {
   password: 'password',

--- a/apps/mull-api/src/app/user/user.module.ts
+++ b/apps/mull-api/src/app/user/user.module.ts
@@ -1,8 +1,7 @@
 import { Module } from '@nestjs/common';
+import { EntitiesModule } from '../entities';
 import { UserResolver } from './user.resolver';
 import { UserService } from './user.service';
-
-import { EntitiesModule } from '../entities';
 
 @Module({
   imports: [EntitiesModule],

--- a/apps/mull-api/src/app/user/user.resolver.spec.ts
+++ b/apps/mull-api/src/app/user/user.resolver.spec.ts
@@ -1,10 +1,10 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { UserResolver } from './user.resolver';
-import { UserService } from './user.service';
-import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
-import { mockPartialUser, mockAllUsers, mockNewPartialUser } from './user.mockdata';
 import { RegistrationMethod } from '@mull/types';
 import { UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
+import { mockAllUsers, mockNewPartialUser, mockPartialUser } from './user.mockdata';
+import { UserResolver } from './user.resolver';
+import { UserService } from './user.service';
 
 const mockUserService = () => ({
   create: jest.fn((mockUserData: CreateUserInput) => ({ ...mockUserData })),

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -1,11 +1,10 @@
-import { Resolver, Query, Mutation, Args, ResolveField, Parent, Int } from '@nestjs/graphql';
-import { genSalt, hash } from 'bcrypt';
-
-import { User } from '../entities';
 import { RegistrationMethod } from '@mull/types';
-import { UserService } from './user.service';
-import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
 import { UnauthorizedException } from '@nestjs/common';
+import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { genSalt, hash } from 'bcrypt';
+import { User } from '../entities';
+import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
+import { UserService } from './user.service';
 
 @Resolver(/* istanbul ignore next */ () => User)
 export class UserResolver {

--- a/apps/mull-api/src/app/user/user.service.spec.ts
+++ b/apps/mull-api/src/app/user/user.service.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UserService } from './user.service';
-import { User } from '../entities';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { FindOneOptions, Repository } from 'typeorm';
+import { User } from '../entities';
 import { CreateUserInput } from './inputs/user.input';
 import { mockAllUsers, mockPartialUser } from './user.mockdata';
-import { FindOneOptions, Repository } from 'typeorm';
+import { UserService } from './user.service';
 
 export type MockType<T> = {
   [P in keyof T]: jest.Mock<{}>;

--- a/apps/mull-api/src/main.ts
+++ b/apps/mull-api/src/main.ts
@@ -4,12 +4,10 @@
  */
 
 import { Logger, ValidationPipe } from '@nestjs/common';
-import * as cookieParser from 'cookie-parser';
 import { NestFactory } from '@nestjs/core';
-
-import { environment } from './environments/environment';
-
+import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/apps/mull-ui/src/app/app.spec.tsx
+++ b/apps/mull-ui/src/app/app.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import App from './app';
-
-import { render } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import App from './app';
 
 describe('App', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -1,23 +1,18 @@
 import React, { CSSProperties } from 'react';
-import SwipeableRoutes from 'react-swipeable-routes';
-
-import { ToastContainer, toast } from 'react-toastify';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
-
+import SwipeableRoutes from 'react-swipeable-routes';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.min.css';
+import { dummyEvent, ROUTES } from '../constants';
+import './app.scss';
+import { BotNavBar, EventCard, SubNavBar, TopNavBar } from './components';
 import CreateEventPage from './pages/create-event/create-event';
-import { TopNavBar, BotNavBar, EventCard, SubNavBar } from './components';
+import EventPage from './pages/event-page/event-page';
+import DiscoverPage from './pages/home/discover/discover-page';
+import MyEventsPage from './pages/home/my-events/my-events';
+import UpcomingPage from './pages/home/upcoming/upcoming';
 import LoginPage from './pages/login/login';
 import RegisterPage from './pages/register/register';
-
-import { ROUTES } from '../constants';
-
-import 'react-toastify/dist/ReactToastify.min.css';
-import './app.scss';
-import { dummyEvent } from '../constants';
-import DiscoverPage from './pages/home/discover/discover-page';
-import UpcomingPage from './pages/home/upcoming/upcoming';
-import MyEventsPage from './pages/home/my-events/my-events';
-import EventPage from './pages/event-page/event-page';
 
 /**
  * Main component of the application

--- a/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.spec.tsx
+++ b/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.spec.tsx
@@ -1,6 +1,5 @@
-import React, { ChangeEvent } from 'react';
 import { render } from '@testing-library/react';
-
+import React, { ChangeEvent } from 'react';
 import CustomFileUpload, { CustomFileUploadProps } from './custom-file-upload';
 
 const mockHandleChange: (e: ChangeEvent<HTMLInputElement>) => void = jest.fn();

--- a/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
+++ b/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
@@ -1,8 +1,7 @@
-import React, { ChangeEvent } from 'react';
-
-import './custom-file-upload.scss';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faImages } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { ChangeEvent } from 'react';
+import './custom-file-upload.scss';
 
 export interface CustomFileUploadProps {
   hasErrors: boolean;

--- a/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.spec.tsx
+++ b/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.spec.tsx
@@ -1,5 +1,5 @@
-import React, { ChangeEvent } from 'react';
 import { render } from '@testing-library/react';
+import React, { ChangeEvent } from 'react';
 import renderer from 'react-test-renderer';
 import CustomTextInput, { CustomTextInputProps } from './custom-text-input';
 

--- a/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
+++ b/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, ReactNode } from 'react';
-
 import './custom-text-input.scss';
 
 export interface CustomTextInputProps {

--- a/apps/mull-ui/src/app/components/custom-time-picker/custom-time-picker.spec.tsx
+++ b/apps/mull-ui/src/app/components/custom-time-picker/custom-time-picker.spec.tsx
@@ -1,5 +1,5 @@
-import React, { ChangeEvent } from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import React, { ChangeEvent } from 'react';
 import renderer from 'react-test-renderer';
 import CustomTimePicker, { CustomTimePickerProps } from './custom-time-picker';
 

--- a/apps/mull-ui/src/app/components/custom-time-picker/custom-time-picker.tsx
+++ b/apps/mull-ui/src/app/components/custom-time-picker/custom-time-picker.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent } from 'react';
-
 import './custom-time-picker.scss';
 
 export interface CustomTimePickerProps {

--- a/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import renderer from 'react-test-renderer';
-
-import EventCard from './event-card';
 import { dummyEvent } from '../../../constants';
+import EventCard from './event-card';
 
 describe('EventCard', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -1,14 +1,11 @@
+import { faCheck, faShareAlt, faSignInAlt } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
 import React, { useState } from 'react';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faShareAlt, faCheck, faSignInAlt } from '@fortawesome/free-solid-svg-icons';
-
-import { formatDate } from '../../../utilities';
-
-import './event-card.scss';
 import { dummyProfilePictures } from '../../../constants'; // TODO query the participants profile pictures
+import { formatDate } from '../../../utilities';
 import EventMembers from '../event-members/event-members';
+import './event-card.scss';
 
 export interface EventCardProps {
   event: Partial<ISerializedEvent>;

--- a/apps/mull-ui/src/app/components/event-members/event-members.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-members/event-members.spec.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-
-import EventMembers from './event-members';
+import React from 'react';
 import { dummyProfilePictures } from '../../../constants';
+import EventMembers from './event-members';
 
 describe('EventMembers', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/event-members/event-members.tsx
+++ b/apps/mull-ui/src/app/components/event-members/event-members.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import './event-members.scss';
 
 export interface EventMembersProps {

--- a/apps/mull-ui/src/app/components/event-page-header/event-page-header.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-page-header/event-page-header.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import renderer from 'react-test-renderer';
-
-import EventPageHeader from './event-page-header';
 import { dummyEvent } from '../../../constants';
+import EventPageHeader from './event-page-header';
 
 describe('EventPageHeader', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/event-page-header/event-page-header.tsx
+++ b/apps/mull-ui/src/app/components/event-page-header/event-page-header.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { faClock } from '@fortawesome/free-regular-svg-icons';
-
-import './event-page-header.scss';
-
+import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
-
-import MullBackButton from '../mull-back-button/mull-back-button';
+import React from 'react';
 import { formatDate } from '../../../utilities';
+import MullBackButton from '../mull-back-button/mull-back-button';
+import './event-page-header.scss';
 
 export interface EventPageHeaderProps {
   event: Partial<ISerializedEvent>;

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import renderer from 'react-test-renderer';
-
-import EventPageInfo from './event-page-info';
 import { dummyEvent } from '../../../constants';
+import EventPageInfo from './event-page-info';
 
 describe('EventPageInfo', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -1,20 +1,18 @@
-import { EventRestrictionMap, ISerializedEvent } from '@mull/types';
-import React from 'react';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faComments,
-  faMapMarkerAlt,
   faAlignLeft,
-  faMap,
+  faComments,
   faLock,
+  faMap,
+  faMapMarkerAlt,
   faUserFriends,
   faUserPlus,
 } from '@fortawesome/free-solid-svg-icons';
-
-import './event-page-info.scss';
-import { ExpandableText } from './../expandable-text/expandable-text';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { EventRestrictionMap, ISerializedEvent } from '@mull/types';
+import React from 'react';
 import MullButton from '../mull-button/mull-button';
+import { ExpandableText } from './../expandable-text/expandable-text';
+import './event-page-info.scss';
 
 export interface EventPageInfoProps {
   event: Partial<ISerializedEvent>;

--- a/apps/mull-ui/src/app/components/expandable-text/expandable-text.spec.tsx
+++ b/apps/mull-ui/src/app/components/expandable-text/expandable-text.spec.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-import renderer from 'react-test-renderer';
+import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-
+import renderer from 'react-test-renderer';
 import ExpandableText from './expandable-text';
 
 describe('ExpandableText', () => {

--- a/apps/mull-ui/src/app/components/expandable-text/expandable-text.tsx
+++ b/apps/mull-ui/src/app/components/expandable-text/expandable-text.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-
 import './expandable-text.scss';
 
 export interface ExpandableTextProps {

--- a/apps/mull-ui/src/app/components/index.ts
+++ b/apps/mull-ui/src/app/components/index.ts
@@ -13,4 +13,3 @@ export * from './navigation/nav-buttons/nav-buttons';
 export * from './navigation/sub-nav-bar/sub-nav-bar';
 export * from './navigation/top-nav-bar/top-nav-bar';
 export * from './pill-options/pill-options';
-export * from './event-members/event-members';

--- a/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.spec.tsx
+++ b/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-import renderer from 'react-test-renderer';
-import ReactTestUtils from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
-
+import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import renderer from 'react-test-renderer';
 import MullBackButton from './mull-back-button';
 
 let mockHistory;

--- a/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.tsx
+++ b/apps/mull-ui/src/app/components/mull-back-button/mull-back-button.tsx
@@ -1,10 +1,8 @@
-import React, { ReactNode } from 'react';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
-
-import './mull-back-button.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { ReactNode } from 'react';
 import { useHistory } from 'react-router-dom';
+import './mull-back-button.scss';
 
 export interface MullBackButtonProps {
   children?: ReactNode;

--- a/apps/mull-ui/src/app/components/mull-button/mull-button.spec.tsx
+++ b/apps/mull-ui/src/app/components/mull-button/mull-button.spec.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import renderer from 'react-test-renderer';
-
 import MullButton from './mull-button';
 
 describe('MullButton', () => {

--- a/apps/mull-ui/src/app/components/mull-button/mull-button.tsx
+++ b/apps/mull-ui/src/app/components/mull-button/mull-button.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import './mull-button.scss';
 
 export interface MullButtonProps {

--- a/apps/mull-ui/src/app/components/navigation/bot-nav-bar/bot-nav-bar.spec.tsx
+++ b/apps/mull-ui/src/app/components/navigation/bot-nav-bar/bot-nav-bar.spec.tsx
@@ -1,12 +1,9 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-
-import BotNavBar from './bot-nav-bar';
-import { Router } from 'react-router-dom';
-
 import { createMemoryHistory } from 'history';
-
+import React from 'react';
+import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
+import BotNavBar from './bot-nav-bar';
 
 describe('BotNavBar', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/navigation/bot-nav-bar/bot-nav-bar.tsx
+++ b/apps/mull-ui/src/app/components/navigation/bot-nav-bar/bot-nav-bar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
-import './bot-nav-bar.scss';
 import NavButtons from '../nav-buttons/nav-buttons';
+import './bot-nav-bar.scss';
 
 /**
  * Component for mobile header.

--- a/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.spec.tsx
+++ b/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.spec.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-
-import NavButtons from './nav-buttons';
-import { Router } from 'react-router-dom';
-
 import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
 import { ROUTES } from '../../../../constants';
+import NavButtons from './nav-buttons';
 
 describe('NavButtons', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.tsx
+++ b/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-
 import { ReactComponent as CreateEventIcon } from '../../../../assets/icons/nav-bar-icons/CreateEventIcon.svg';
 import { ReactComponent as HomeIcon } from '../../../../assets/icons/nav-bar-icons/HomeIcon.svg';
+import { ReactComponent as MachineLearningIcon } from '../../../../assets/icons/nav-bar-icons/MachineLearningIcon.svg';
 import { ReactComponent as MapIcon } from '../../../../assets/icons/nav-bar-icons/MapIcon.svg';
 import { ReactComponent as MessagesIcon } from '../../../../assets/icons/nav-bar-icons/MessagesIcon.svg';
-import { ReactComponent as MachineLearningIcon } from '../../../../assets/icons/nav-bar-icons/MachineLearningIcon.svg';
 import { ROUTES } from '../../../../constants';
-
 import './nav-buttons.scss';
 
 export const NavButtons = () => {

--- a/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.spec.tsx
+++ b/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.spec.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
-import SubNavBar from './sub-nav-bar';
-
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import React from 'react';
 import { Router } from 'react-router-dom';
-
+import renderer from 'react-test-renderer';
 import { ROUTES } from '../../../../constants';
+import SubNavBar from './sub-nav-bar';
 
 describe('SubNavBar', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.tsx
+++ b/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.tsx
@@ -1,7 +1,6 @@
-import { ROUTES } from '../../../../constants';
 import React, { CSSProperties } from 'react';
 import { NavLink } from 'react-router-dom';
-
+import { ROUTES } from '../../../../constants';
 import './sub-nav-bar.scss';
 
 export interface SubNavBarProps {

--- a/apps/mull-ui/src/app/components/navigation/top-nav-bar/top-nav-bar.spec.tsx
+++ b/apps/mull-ui/src/app/components/navigation/top-nav-bar/top-nav-bar.spec.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-
-import TopNavBar from './top-nav-bar';
-import { Router } from 'react-router-dom';
-
 import { createMemoryHistory } from 'history';
-import { ROUTES } from '../../../../constants';
-
+import React from 'react';
+import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
+import { ROUTES } from '../../../../constants';
+import TopNavBar from './top-nav-bar';
 
 describe('TopNavBar', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/components/navigation/top-nav-bar/top-nav-bar.tsx
+++ b/apps/mull-ui/src/app/components/navigation/top-nav-bar/top-nav-bar.tsx
@@ -1,12 +1,10 @@
 import React, { CSSProperties } from 'react';
-
-import './top-nav-bar.scss';
-
+import { NavLink } from 'react-router-dom';
 import { ReactComponent as ProfileIcon } from '../../../../assets/icons/nav-bar-icons/ProfileIcon.svg';
 import logo from '../../../../assets/mull-logo.png';
-import { NavLink } from 'react-router-dom';
 import { ROUTES } from '../../../../constants';
 import NavButtons from '../nav-buttons/nav-buttons';
+import './top-nav-bar.scss';
 
 export interface TopNavBarProps {
   style?: CSSProperties;

--- a/apps/mull-ui/src/app/components/pill-options/pill-options.spec.tsx
+++ b/apps/mull-ui/src/app/components/pill-options/pill-options.spec.tsx
@@ -1,7 +1,7 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import PillOptions from './pill-options';
 
 const mockOptions: string[] = ['Yes', 'No', 'Maybe'];

--- a/apps/mull-ui/src/app/components/pill-options/pill-options.tsx
+++ b/apps/mull-ui/src/app/components/pill-options/pill-options.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import './pill-options.scss';
 
 export interface PillOptionsProps {

--- a/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import user from '@testing-library/user-event';
-import { fireEvent, render, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { MockedProvider } from '@apollo/client/testing';
-import CreateEventPage, { UPLOAD_PHOTO } from './create-event';
-import { Router } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
 import { ROUTES } from '../../../constants';
+import CreateEventPage, { UPLOAD_PHOTO } from './create-event';
 
 describe('CreateEvent', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -1,29 +1,25 @@
-import React, { ChangeEvent, useState } from 'react';
-import { useMutation, gql } from '@apollo/client';
+import { gql, useMutation } from '@apollo/client';
+import { faAlignLeft, faMapMarkerAlt, faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { EventRestriction, EventRestrictionMap, IMedia, ISerializedEvent } from '@mull/types';
 import { FormikTouched, FormikValues, setNestedObjectValues, useFormik } from 'formik';
+import { History } from 'history';
+import { cloneDeep, isEmpty } from 'lodash';
+import React, { ChangeEvent, useState } from 'react';
 import { toast } from 'react-toastify';
 import * as Yup from 'yup';
-import { cloneDeep, isEmpty } from 'lodash';
-import { History } from 'history';
-
+import { DAY_IN_MILLISECONDS, ROUTES } from '../../../constants';
+import { useToast } from '../../hooks/useToast';
 import {
-  MullButton,
   CustomFileUpload,
-  PillOptions,
   CustomTextInput,
   CustomTimePicker,
+  MullButton,
+  PillOptions,
 } from './../../components';
-import DateCalendar from './date-calendar/date-calendar';
 import { EventPage } from './../event-page/event-page';
-import { useToast } from '../../hooks/useToast';
-
-import { EventRestriction, EventRestrictionMap, IMedia, ISerializedEvent } from '@mull/types';
-import { DAY_IN_MILLISECONDS, ROUTES } from '../../../constants';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAlignLeft, faPencilAlt, faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
-
 import './create-event.scss';
+import DateCalendar from './date-calendar/date-calendar';
 
 export interface CreateEventProps {
   history: History;

--- a/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.spec.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import DateCalendar, { DateCalendarProps } from './date-calendar';
 
 const mockOnStartDateChange: (date: Date) => void = jest.fn();

--- a/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { enGB } from 'date-fns/locale';
+import React, { useState } from 'react';
 import { DateRangeFocus, DateRangePickerCalendar } from 'react-nice-dates';
 import 'react-nice-dates/build/style.css';
 import './date-calendar.scss';

--- a/apps/mull-ui/src/app/pages/event-page/event-page.spec.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.spec.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import renderer from 'react-test-renderer';
-
-import EventPage from './event-page';
-import { dummyEvent } from '../../../constants';
-import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import renderer from 'react-test-renderer';
+import { dummyEvent } from '../../../constants';
+import EventPage from './event-page';
 
 describe('EventPage', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -1,10 +1,8 @@
+import { gql, useQuery } from '@apollo/client';
 import { ISerializedEvent } from '@mull/types';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { EventPageHeader, EventPageInfo } from '../../components';
-
-import { gql, useQuery } from '@apollo/client';
-
 import './event-page.scss';
 
 export interface EventPageProps {

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { ISerializedEvent } from '@mull/types';
-import { EventCard } from '../../../components';
 import { gql, useQuery } from '@apollo/client';
-
+import { ISerializedEvent } from '@mull/types';
+import React from 'react';
+import { EventCard } from '../../../components';
 import '../home-discover.scss';
 
 interface DiscoverData {

--- a/apps/mull-ui/src/app/pages/login/login.spec.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.spec.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { MockedProvider } from '@apollo/client/testing';
-import Login from './login';
-import { Router } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
 import { ROUTES } from '../../../constants';
+import Login from './login';
 
 describe('Login', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -1,16 +1,13 @@
+import { faFacebookSquare, faGoogle, faTwitter } from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useFormik } from 'formik';
+import { History } from 'history';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { History } from 'history';
 import * as Yup from 'yup';
-import { useFormik } from 'formik';
-
-import { CustomTextInput } from '../../components';
-import { environment } from '../../../environments/environment';
-
 import logo from '../../../assets/mull-logo.png';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFacebookSquare, faGoogle, faTwitter } from '@fortawesome/free-brands-svg-icons';
-
+import { environment } from '../../../environments/environment';
+import { CustomTextInput } from '../../components';
 import './login.scss';
 
 export interface LoginProps {

--- a/apps/mull-ui/src/app/pages/register/register.spec.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.spec.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
-import Register, { CREATE_USER } from './register';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
-import { ROUTES } from '../../../constants';
 import { RegistrationMethod } from '@mull/types';
+import '@testing-library/jest-dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { ROUTES } from '../../../constants';
+import Register, { CREATE_USER } from './register';
 
 describe('Register', () => {
   it('should render successfully', () => {

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -1,17 +1,14 @@
-import React from 'react';
 import { ApolloError, gql, useMutation } from '@apollo/client';
-import * as Yup from 'yup';
-import { toast } from 'react-toastify';
-import { useFormik } from 'formik';
-import { Link } from 'react-router-dom';
-import { History } from 'history';
-
-import { CustomTextInput } from '../../components';
 import { RegistrationMethod } from '@mull/types';
-import { useToast } from '../../hooks/useToast';
-
+import { useFormik } from 'formik';
+import { History } from 'history';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import * as Yup from 'yup';
 import logo from '../../../assets/mull-logo.png';
-
+import { CustomTextInput } from '../../components';
+import { useToast } from '../../hooks/useToast';
 import './register.scss';
 
 export interface RegisterProps {

--- a/apps/mull-ui/src/main.tsx
+++ b/apps/mull-ui/src/main.tsx
@@ -1,13 +1,10 @@
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+import { createUploadLink } from 'apollo-upload-client';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-
-import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
-import { environment } from './environments/environment';
-
-import { createUploadLink } from 'apollo-upload-client';
-
 import App from './app/app';
+import { environment } from './environments/environment';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function () {

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -1,5 +1,5 @@
 // Types go here
-import { Response, Request } from 'express';
+import { Request, Response } from 'express';
 export interface Message {
   message: string;
   info: { production: boolean };


### PR DESCRIPTION
Added workspace settings to attempt to make some of our workflow a bit more consistent. These settings are applied to everyone who works on our repository with vscode can be updated and added upon over time.

A few examples of vscode settings I felt we should all have:
1. defaultFormatter: 100000 times I've seen one of our teammates complain that their formatters isn't working, when in fact they had multiple formatters present for a given file type and didn't pick a default one.
2. codeActionsOnSave: Our imports are all over the place, with no consistency as to how they are ordered, the organizeImports on save fixes this, and uses our linter, eslint, with no need for extra plugins! Another bonus, it cleans up unused imports!
3. formatOnSave. Self-explanatory, I think everyone should have this.

I'm open to suggestions of other things we'd need to add for these workspace settings.