### PR TITLE
TASK-38: Remove participant from events

### DIFF
--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -80,7 +80,7 @@ describe('UserResolver', () => {
   });
 
   it('should remove the participant from the event', async () => {
-    const success = await resolver.removeParticipantToEvent(35, 1);
+    const success = await resolver.removeParticipantFromEvent(35, 1);
     expect(success).toEqual(true);
   });
 

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -17,6 +17,13 @@ const mockEventService = () => ({
     event.participants.push(new User(userId));
     return event;
   }),
+  removeParticipant: jest.fn((eventId: number, userId: number) => {
+    const event = mockAllEvents.find((event) => (event.id = eventId));
+    const user = event.participants.find((participant) => participant.id == userId);
+    const index = event.participants.indexOf(user);
+    event.participants.splice(index, 1);
+    return event;
+  }),
   findHostEvents: jest.fn((id: number) => mockAllEvents.find((event) => event.host.id === id)),
   findCoHostEvents: jest.fn((coHostId: number) =>
     mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
@@ -69,6 +76,11 @@ describe('UserResolver', () => {
 
   it('should add the participant to the event', async () => {
     const success = await resolver.addParticipantToEvent(35, 1);
+    expect(success).toEqual(true);
+  });
+
+  it('should remove the participant from the event', async () => {
+    const success = await resolver.removeParticipantToEvent(35, 1);
     expect(success).toEqual(true);
   });
 

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -61,7 +61,10 @@ export class EventResolver {
   }
 
   @Mutation(() => Boolean)
-  async removeParticipantToEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+  async removeParticipantFromEvent(
+    @Args('eventId') eventId: number,
+    @Args('userId') userId: number
+  ) {
     this.eventService.removeParticipant(eventId, userId);
     return true;
   }

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -59,4 +59,10 @@ export class EventResolver {
     this.eventService.addParticipant(eventId, userId);
     return true;
   }
+
+  @Mutation(() => Boolean)
+  async removeParticipantToEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+    this.eventService.removeParticipant(eventId, userId);
+    return true;
+  }
 }

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -82,6 +82,16 @@ describe('EventService', () => {
     expect(updatedEvent.participants.pop().id).toEqual(userId);
   });
 
+  it('should remove the participant from the event', async () => {
+    const eventId = 35;
+    const userId = 3;
+    const event = await service.findOne(eventId);
+    const oldSize = event.participants.length;
+
+    const updatedEvent = await service.removeParticipant(eventId, userId);
+    expect(updatedEvent.participants.length).toBeLessThan(oldSize);
+  });
+
   it('should return the event with given id', async () => {
     const foundEvent = await service.findOne(35);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.id === 35));

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -92,6 +92,16 @@ describe('EventService', () => {
     expect(updatedEvent.participants.length).toBeLessThan(oldSize);
   });
 
+  it('should throw an error if user is not a participant of the event', async () => {
+    const eventId = 35;
+    const userId = 150;
+    try {
+      await service.removeParticipant(eventId, userId);
+    } catch (error) {
+      expect(error).toEqual(new Error('User is not a participant of the event'));
+    }
+  });
+
   it('should return the event with given id', async () => {
     const foundEvent = await service.findOne(35);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.id === 35));

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -92,6 +92,14 @@ export class EventService {
     return await this.eventRepository.save(event);
   }
 
+  async removeParticipant(eventId: number, userId: number) {
+    const event = await this.eventRepository.findOne(eventId, { relations: ['participants'] });
+    const user = event.participants.find((participant) => participant.id == userId);
+    const index = event.participants.indexOf(user);
+    event.participants.splice(index, 1);
+    return await this.eventRepository.save(event);
+  }
+
   async delete(id: number): Promise<Event> {
     const event = await this.findOne(id);
     await this.eventRepository.delete(event.id);

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -94,10 +94,18 @@ export class EventService {
 
   async removeParticipant(eventId: number, userId: number) {
     const event = await this.eventRepository.findOne(eventId, { relations: ['participants'] });
+    if (event == undefined) {
+      throw new Error('Event does not exist');
+    }
+
     const user = event.participants.find((participant) => participant.id == userId);
-    const index = event.participants.indexOf(user);
-    event.participants.splice(index, 1);
-    return await this.eventRepository.save(event);
+    if (user == undefined) {
+      throw new Error('User is not a participant of the event');
+    } else {
+      const index = event.participants.indexOf(user);
+      event.participants.splice(index, 1);
+      return await this.eventRepository.save(event);
+    }
   }
 
   async delete(id: number): Promise<Event> {

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -60,7 +60,7 @@ type Mutation {
   deleteEvent(id: Int!): Event!
   deleteUser(id: Int!): User!
   login(loginInput: LoginInput!): LoginResult!
-  removeParticipantToEvent(eventId: Float!, userId: Float!): Boolean!
+  removeParticipantFromEvent(eventId: Float!, userId: Float!): Boolean!
   updateEvent(updateEventInput: UpdateEventInput!): Event!
   updateUser(updateUserInput: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -60,6 +60,7 @@ type Mutation {
   deleteEvent(id: Int!): Event!
   deleteUser(id: Int!): User!
   login(loginInput: LoginInput!): LoginResult!
+  removeParticipantToEvent(eventId: Float!, userId: Float!): Boolean!
   updateEvent(updateEventInput: UpdateEventInput!): Event!
   updateUser(updateUserInput: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!


### PR DESCRIPTION
This PR closes #136 

To properly test this PR you will need to set up your database such that a user with an id that exists in the user table (EG: userId 1)

- Is a participant in at least 1 event, meaning they're in the event_participants table

Steps to test: 
1. Run `npm run start mull-api`
1. Go to http://localhost:3333/graphql
1. Use the removeParticipantToEvent mutation to remove a participant from a specific event. EG: ` mutation {
      removeParticipantToEvent(eventId:1, userId: 8)
}` (Given that an event with id 1 and user with id 8 exists in your database)