### PR TITLE
TASK-35: Setup VSCode Debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Mull-UI",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}/apps/mull-ui/src/",
+      "skipFiles": ["${workspaceRoot}/node_modules/**/*.js", "<node_internals>/**/*.js"]
+    },
+    {
+      "name": "Debug Mull-API",
+      "type": "node",
+      "request": "launch",
+      "sourceMaps": true,
+      "program": "${workspaceFolder}/apps/mull-api/src/main.ts",
+      "port": 3333,
+      "console": "integratedTerminal",
+      "skipFiles": ["${workspaceRoot}/node_modules/**/*.js", "<node_internals>/**/*.js"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR closes #127.

**Steps to Test Frontend**
1. Start the application using `nx serve mull-ui`.
2. Go to the debugger tab on VSCode.
3. In the drop-down menu next to 'RUN', select `Debug Mull-UI`.
4. Click the green play button next to it.
5. Place a breakpoint in the code by pressing to the left of the line number.
6. Perform an action that would trigger the breakpoint.
7. Interact with the debugger.

**Steps to Test Backend**

1. Go to the debugger tab on VSCode.
1. In the drop-down menu next to 'RUN', select `Debug Mull-API`.
1. Click the green play button next to it.
1. Place a breakpoint in the code by pressing to the left of the line number.
1. Perform an action that would trigger the breakpoint.
1. Interact with the debugger.

Notes: I tried ignoring node modules but I could not get it working so the debugger will jump into the node modules from time to time.