### PR TITLE
FIX: Refactor backend method names

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "nrwl.angular-console", "yzhang.markdown-all-in-one"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "nrwl.angular-console",
+    "yzhang.markdown-all-in-one"
+  ]
 }

--- a/apps/mull-api/src/app/auth/auth.controller.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.spec.ts
@@ -18,7 +18,7 @@ const mockAuthService = () => ({
 });
 
 const mockUserService = () => ({
-  findOne: jest.fn(),
+  user: jest.fn(),
 });
 
 const mockJwtService = () => ({

--- a/apps/mull-api/src/app/auth/auth.controller.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.spec.ts
@@ -93,7 +93,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: mockAllUsers[0].tokenVersion,
     });
-    userService.findOne.mockReturnValue({ ...mockAllUsers[0] });
+    userService.user.mockReturnValue({ ...mockAllUsers[0] });
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: true, accessToken: 'accessToken' });
@@ -123,7 +123,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: mockAllUsers[0].tokenVersion,
     });
-    userService.findOne.mockReturnValue(null);
+    userService.user.mockReturnValue(null);
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: false, accessToken: '' });
@@ -136,7 +136,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: 1,
     });
-    userService.findOne.mockReturnValue({ ...mockAllUsers[0] });
+    userService.user.mockReturnValue({ ...mockAllUsers[0] });
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: false, accessToken: '' });

--- a/apps/mull-api/src/app/auth/auth.controller.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.spec.ts
@@ -18,7 +18,7 @@ const mockAuthService = () => ({
 });
 
 const mockUserService = () => ({
-  user: jest.fn(),
+  getUser: jest.fn(),
 });
 
 const mockJwtService = () => ({
@@ -93,7 +93,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: mockAllUsers[0].tokenVersion,
     });
-    userService.user.mockReturnValue({ ...mockAllUsers[0] });
+    userService.getUser.mockReturnValue({ ...mockAllUsers[0] });
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: true, accessToken: 'accessToken' });
@@ -123,7 +123,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: mockAllUsers[0].tokenVersion,
     });
-    userService.user.mockReturnValue(null);
+    userService.getUser.mockReturnValue(null);
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: false, accessToken: '' });
@@ -136,7 +136,7 @@ describe('Auth Controller', () => {
       id: mockAllUsers[0].id,
       tokenVersion: 1,
     });
-    userService.user.mockReturnValue({ ...mockAllUsers[0] });
+    userService.getUser.mockReturnValue({ ...mockAllUsers[0] });
     authService.createAccessToken.mockReturnValue('accessToken');
     await controller.refreshToken(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledWith({ ok: false, accessToken: '' });

--- a/apps/mull-api/src/app/auth/auth.controller.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.ts
@@ -61,7 +61,7 @@ export class AuthController {
     } catch (err) {
       return res.send({ ok: false, accessToken: '' });
     }
-    const user = await this.userService.user(id);
+    const user = await this.userService.getUser(id);
 
     if (!user) return res.send({ ok: false, accessToken: '' });
     if (user.tokenVersion !== tokenVersion) return res.send({ ok: false, accessToken: '' });

--- a/apps/mull-api/src/app/auth/auth.controller.ts
+++ b/apps/mull-api/src/app/auth/auth.controller.ts
@@ -61,7 +61,7 @@ export class AuthController {
     } catch (err) {
       return res.send({ ok: false, accessToken: '' });
     }
-    const user = await this.userService.findOne(id);
+    const user = await this.userService.user(id);
 
     if (!user) return res.send({ ok: false, accessToken: '' });
     if (user.tokenVersion !== tokenVersion) return res.send({ ok: false, accessToken: '' });

--- a/apps/mull-api/src/app/auth/auth.service.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.service.spec.ts
@@ -11,7 +11,7 @@ import { AuthService } from './auth.service';
 
 const mockUserService = () => ({
   findUnique: jest.fn(),
-  create: jest.fn((user: CreateUserInput) => user),
+  createUser: jest.fn((user: CreateUserInput) => user),
   incrementTokenVersion: jest.fn(),
 });
 

--- a/apps/mull-api/src/app/auth/auth.service.ts
+++ b/apps/mull-api/src/app/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
     const users: User[] = await this.userService.findUnique(user.email, user.registrationMethod);
     if (users.length == 1) callback(null, users[0]);
     else {
-      const newUser = await this.userService.create(user as CreateUserInput);
+      const newUser = await this.userService.createUser(user as CreateUserInput);
       callback(null, newUser);
     }
   }

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -75,12 +75,12 @@ describe('UserResolver', () => {
   });
 
   it('should add the participant to the event', async () => {
-    const success = await resolver.addParticipantToEvent(35, 1);
+    const success = await resolver.joinEvent(35, 1);
     expect(success).toEqual(true);
   });
 
   it('should remove the participant from the event', async () => {
-    const success = await resolver.removeParticipantFromEvent(35, 1);
+    const success = await resolver.leaveEvent(35, 1);
     expect(success).toEqual(true);
   });
 
@@ -95,31 +95,31 @@ describe('UserResolver', () => {
     expect(foundEvents).toEqual(
       mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
     );
-    expect(service.findCoHostEvents).toBeCalledTimes(1);
+    expect(service.coHostEvents).toBeCalledTimes(1);
   });
 
   it('should return a list of events that belongs to a host', async () => {
     const hostId = mockAllUsers[0].id;
     const foundEvents = await resolver.hostEvents(hostId);
     expect(foundEvents).toEqual(mockAllEvents.find((event) => event.host.id === hostId));
-    expect(service.findHostEvents).toBeCalledTimes(1);
+    expect(service.hostEvents).toBeCalledTimes(1);
   });
 
   it('should return a list of events that a user has joined', async () => {
     const participantId = mockAllUsers[2].id;
-    const foundEvents = await resolver.participatingEvents(participantId);
+    const foundEvents = await resolver.participantEvents(participantId);
     expect(foundEvents).toEqual(
       mockAllEvents.find((event) =>
         event.participants.some((participant) => participant.id === participantId)
       )
     );
-    expect(service.findJoinedEvents).toBeCalledTimes(1);
+    expect(service.participantEvents).toBeCalledTimes(1);
   });
 
   it('should return a list of events that the user is not involved with', async () => {
     const id = mockAllUsers[2].id;
     const foundEvents = await resolver.discoverEvents(id);
     expect(foundEvents).toEqual(mockAllEvents[2]);
-    expect(service.findDiscoverEvent).toBeCalledTimes(1);
+    expect(service.discoverEvents).toBeCalledTimes(1);
   });
 });

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -7,33 +7,33 @@ import { EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 
 const mockEventService = () => ({
-  create: jest.fn((mockEventData: CreateEventInput) => ({ ...mockEventData })),
-  findOne: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
-  findAll: jest.fn(() => mockAllEvents),
-  update: jest.fn((mockEventData: UpdateEventInput) => ({ ...mockEventData })),
-  delete: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
-  addParticipant: jest.fn((eventId: number, userId: number) => {
+  createEvent: jest.fn((mockEventData: CreateEventInput) => ({ ...mockEventData })),
+  event: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
+  events: jest.fn(() => mockAllEvents),
+  updateEvent: jest.fn((mockEventData: UpdateEventInput) => ({ ...mockEventData })),
+  deleteEvent: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
+  joinEvent: jest.fn((eventId: number, userId: number) => {
     const event = mockAllEvents.find((event) => (event.id = eventId));
     event.participants.push(new User(userId));
     return event;
   }),
-  removeParticipant: jest.fn((eventId: number, userId: number) => {
+  leaveEvent: jest.fn((eventId: number, userId: number) => {
     const event = mockAllEvents.find((event) => (event.id = eventId));
     const user = event.participants.find((participant) => participant.id == userId);
     const index = event.participants.indexOf(user);
     event.participants.splice(index, 1);
     return event;
   }),
-  findHostEvents: jest.fn((id: number) => mockAllEvents.find((event) => event.host.id === id)),
-  findCoHostEvents: jest.fn((coHostId: number) =>
+  hostEvents: jest.fn((id: number) => mockAllEvents.find((event) => event.host.id === id)),
+  coHostEvents: jest.fn((coHostId: number) =>
     mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
   ),
-  findJoinedEvents: jest.fn((participantId: number) =>
+  participantEvents: jest.fn((participantId: number) =>
     mockAllEvents.find((event) =>
       event.participants.some((participant) => participant.id === participantId)
     )
   ),
-  findDiscoverEvent: jest.fn().mockReturnValue(mockAllEvents[2]),
+  discoverEvents: jest.fn().mockReturnValue(mockAllEvents[2]),
 });
 
 describe('UserResolver', () => {

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -8,32 +8,34 @@ import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 
 const mockEventService = () => ({
   createEvent: jest.fn((mockEventData: CreateEventInput) => ({ ...mockEventData })),
-  event: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
-  events: jest.fn(() => mockAllEvents),
+  getEvent: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
+  getAllEvents: jest.fn(() => mockAllEvents),
   updateEvent: jest.fn((mockEventData: UpdateEventInput) => ({ ...mockEventData })),
   deleteEvent: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
-  joinEvent: jest.fn((eventId: number, userId: number) => {
+  addEventParticipant: jest.fn((eventId: number, userId: number) => {
     const event = mockAllEvents.find((event) => (event.id = eventId));
     event.participants.push(new User(userId));
     return event;
   }),
-  leaveEvent: jest.fn((eventId: number, userId: number) => {
+  removeEventParticipant: jest.fn((eventId: number, userId: number) => {
     const event = mockAllEvents.find((event) => (event.id = eventId));
     const user = event.participants.find((participant) => participant.id == userId);
     const index = event.participants.indexOf(user);
     event.participants.splice(index, 1);
     return event;
   }),
-  hostEvents: jest.fn((id: number) => mockAllEvents.find((event) => event.host.id === id)),
-  coHostEvents: jest.fn((coHostId: number) =>
+  getEventsHostedByUser: jest.fn((id: number) =>
+    mockAllEvents.find((event) => event.host.id === id)
+  ),
+  getEventsCoHostedByUser: jest.fn((coHostId: number) =>
     mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
   ),
-  participantEvents: jest.fn((participantId: number) =>
+  getEventsAttendedByUser: jest.fn((participantId: number) =>
     mockAllEvents.find((event) =>
       event.participants.some((participant) => participant.id === participantId)
     )
   ),
-  discoverEvents: jest.fn().mockReturnValue(mockAllEvents[2]),
+  getEventsRecommendedToUser: jest.fn().mockReturnValue(mockAllEvents[2]),
 });
 
 describe('UserResolver', () => {
@@ -95,14 +97,14 @@ describe('UserResolver', () => {
     expect(foundEvents).toEqual(
       mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
     );
-    expect(service.coHostEvents).toBeCalledTimes(1);
+    expect(service.getEventsCoHostedByUser).toBeCalledTimes(1);
   });
 
   it('should return a list of events that belongs to a host', async () => {
     const hostId = mockAllUsers[0].id;
     const foundEvents = await resolver.hostEvents(hostId);
     expect(foundEvents).toEqual(mockAllEvents.find((event) => event.host.id === hostId));
-    expect(service.hostEvents).toBeCalledTimes(1);
+    expect(service.getEventsHostedByUser).toBeCalledTimes(1);
   });
 
   it('should return a list of events that a user has joined', async () => {
@@ -113,13 +115,13 @@ describe('UserResolver', () => {
         event.participants.some((participant) => participant.id === participantId)
       )
     );
-    expect(service.participantEvents).toBeCalledTimes(1);
+    expect(service.getEventsAttendedByUser).toBeCalledTimes(1);
   });
 
   it('should return a list of events that the user is not involved with', async () => {
     const id = mockAllUsers[2].id;
     const foundEvents = await resolver.discoverEvents(id);
     expect(foundEvents).toEqual(mockAllEvents[2]);
-    expect(service.discoverEvents).toBeCalledTimes(1);
+    expect(service.getEventsRecommendedToUser).toBeCalledTimes(1);
   });
 });

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -9,48 +9,48 @@ export class EventResolver {
 
   @Query(/* istanbul ignore next */ () => [Event])
   async events() {
-    return this.eventService.events();
+    return this.eventService.getAllEvents();
   }
 
   @Query(/* istanbul ignore next */ () => Event)
   async event(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.event(id);
+    return this.eventService.getEvent(id);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
   async hostEvents(@Args('hostId', { type: /* istanbul ignore next */ () => Int }) hostId: number) {
-    return this.eventService.hostEvents(hostId);
+    return this.eventService.getEventsHostedByUser(hostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
   async coHostEvents(
     @Args('coHostId', { type: /* istanbul ignore next */ () => Int }) coHostId: number
   ) {
-    return this.eventService.coHostEvents(coHostId);
+    return this.eventService.getEventsCoHostedByUser(coHostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
   async participantEvents(
     @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
   ) {
-    return this.eventService.participantEvents(userId);
+    return this.eventService.getEventsAttendedByUser(userId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
   async discoverEvents(
     @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
   ) {
-    return this.eventService.discoverEvents(userId);
+    return this.eventService.getEventsRecommendedToUser(userId);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
-  async createEvent(@Args('input') input: CreateEventInput) {
-    return this.eventService.createEvent(input);
+  async createEvent(@Args('event') event: CreateEventInput) {
+    return this.eventService.createEvent(event);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
-  async updateEvent(@Args('input') input: UpdateEventInput) {
-    return this.eventService.updateEvent(input);
+  async updateEvent(@Args('event') event: UpdateEventInput) {
+    return this.eventService.updateEvent(event);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
@@ -60,13 +60,13 @@ export class EventResolver {
 
   @Mutation(() => Boolean)
   async joinEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
-    this.eventService.joinEvent(eventId, userId);
+    this.eventService.addEventParticipant(eventId, userId);
     return true;
   }
 
   @Mutation(() => Boolean)
   async leaveEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
-    this.eventService.leaveEvent(eventId, userId);
+    this.eventService.removeEventParticipant(eventId, userId);
     return true;
   }
 }

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -9,63 +9,64 @@ export class EventResolver {
 
   @Query(/* istanbul ignore next */ () => [Event])
   async events() {
-    return this.eventService.findAll();
+    return this.eventService.events();
   }
 
   @Query(/* istanbul ignore next */ () => Event)
   async event(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.findOne(id);
+    return this.eventService.event(id);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async hostEvents(@Args('userId', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.findHostEvents(id);
+  async hostEvents(@Args('hostId', { type: /* istanbul ignore next */ () => Int }) hostId: number) {
+    return this.eventService.hostEvents(hostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async coHostEvents(@Args('userId', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.findCoHostEvents(id);
-  }
-
-  @Query(/* istanbul ignore next */ () => [Event])
-  async participatingEvents(
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) id: number
+  async coHostEvents(
+    @Args('coHostId', { type: /* istanbul ignore next */ () => Int }) coHostId: number
   ) {
-    return this.eventService.findJoinedEvents(id);
+    return this.eventService.coHostEvents(coHostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async discoverEvents(@Args('userId', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.findDiscoverEvent(id);
+  async participantEvents(
+    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+  ) {
+    return this.eventService.participantEvents(userId);
+  }
+
+  @Query(/* istanbul ignore next */ () => [Event])
+  async discoverEvents(
+    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+  ) {
+    return this.eventService.discoverEvents(userId);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
-  async createEvent(@Args('createEventInput') createEventInput: CreateEventInput) {
-    return this.eventService.create(createEventInput);
+  async createEvent(@Args('input') input: CreateEventInput) {
+    return this.eventService.createEvent(input);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
-  async updateEvent(@Args('updateEventInput') updateEventInput: UpdateEventInput) {
-    return this.eventService.update(updateEventInput);
+  async updateEvent(@Args('input') input: UpdateEventInput) {
+    return this.eventService.updateEvent(input);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
   async deleteEvent(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.eventService.delete(id);
+    return this.eventService.deleteEvent(id);
   }
 
   @Mutation(() => Boolean)
-  async addParticipantToEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
-    this.eventService.addParticipant(eventId, userId);
+  async joinEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+    this.eventService.joinEvent(eventId, userId);
     return true;
   }
 
   @Mutation(() => Boolean)
-  async removeParticipantFromEvent(
-    @Args('eventId') eventId: number,
-    @Args('userId') userId: number
-  ) {
-    this.eventService.removeParticipant(eventId, userId);
+  async leaveEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+    this.eventService.leaveEvent(eventId, userId);
     return true;
   }
 }

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -52,32 +52,32 @@ describe('EventService', () => {
   });
 
   it('should create the event', async () => {
-    const returnedEvent = await service.create(mockPartialEvent as CreateEventInput);
+    const returnedEvent = await service.createEvent(mockPartialEvent as CreateEventInput);
     expect(returnedEvent).toEqual(mockPartialEvent);
   });
 
   it('should fetch all events', async () => {
-    const returnedEvents = await service.findAll();
+    const returnedEvents = await service.events();
     expect(returnedEvents).toEqual(mockAllEvents);
   });
 
   it('should update the event', async () => {
-    const updatedEvent = await service.update(mockAllEvents[0]);
+    const updatedEvent = await service.updateEvent(mockAllEvents[0]);
     expect(updatedEvent).toEqual(mockAllEvents[0]);
   });
 
   it('should return the deleted event', async () => {
-    const deletedEvent = await service.delete(35);
+    const deletedEvent = await service.deleteEvent(35);
     expect(deletedEvent).toEqual(mockAllEvents.find((event) => event.id === 35));
   });
 
   it('should add the participant to the event', async () => {
     const eventId = 35;
     const userId = 1;
-    const event = await service.findOne(eventId);
+    const event = await service.event(eventId);
     const oldSize = event.participants.length;
 
-    const updatedEvent = await service.addParticipant(eventId, userId);
+    const updatedEvent = await service.joinEvent(eventId, userId);
     expect(updatedEvent.participants.length).toBeGreaterThan(oldSize);
     expect(updatedEvent.participants.pop().id).toEqual(userId);
   });
@@ -85,10 +85,10 @@ describe('EventService', () => {
   it('should remove the participant from the event', async () => {
     const eventId = 35;
     const userId = 3;
-    const event = await service.findOne(eventId);
+    const event = await service.event(eventId);
     const oldSize = event.participants.length;
 
-    const updatedEvent = await service.removeParticipant(eventId, userId);
+    const updatedEvent = await service.leaveEvent(eventId, userId);
     expect(updatedEvent.participants.length).toBeLessThan(oldSize);
   });
 
@@ -96,21 +96,21 @@ describe('EventService', () => {
     const eventId = 35;
     const userId = 150;
     try {
-      await service.removeParticipant(eventId, userId);
+      await service.leaveEvent(eventId, userId);
     } catch (error) {
       expect(error).toEqual(new Error('User is not a participant of the event'));
     }
   });
 
   it('should return the event with given id', async () => {
-    const foundEvent = await service.findOne(35);
+    const foundEvent = await service.event(35);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.id === 35));
   });
 
   it('should return a list of events that belongs to a host', async () => {
     const hostId = mockAllUsers[1].id;
     repository.find.mockReturnValue(mockAllEvents.find((event) => event.host.id === hostId));
-    const foundEvent = await service.findHostEvents(hostId);
+    const foundEvent = await service.hostEvents(hostId);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.host.id === hostId));
     expect(repository.find).toBeCalledTimes(1);
   });
@@ -126,7 +126,7 @@ describe('EventService', () => {
           mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
         ),
     }));
-    const foundEvent = await service.findCoHostEvents(coHostId);
+    const foundEvent = await service.coHostEvents(coHostId);
     expect(foundEvent).toEqual(
       mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
     );
@@ -146,7 +146,7 @@ describe('EventService', () => {
           )
         ),
     }));
-    const foundEvents = await service.findJoinedEvents(userId);
+    const foundEvents = await service.participantEvents(userId);
     expect(foundEvents).toEqual(
       mockAllEvents.find((event) =>
         event.participants.some((participant) => participant.id === userId)
@@ -163,7 +163,7 @@ describe('EventService', () => {
       andWhere: jest.fn().mockReturnThis(),
       getMany: jest.fn().mockReturnValue(mockAllEvents[2]),
     }));
-    const foundEvents = await service.findDiscoverEvent(userId);
+    const foundEvents = await service.discoverEvents(userId);
     expect(foundEvents).toEqual(mockAllEvents[2]);
     expect(repository.createQueryBuilder).toBeCalledTimes(1);
   });

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -57,7 +57,7 @@ describe('EventService', () => {
   });
 
   it('should fetch all events', async () => {
-    const returnedEvents = await service.events();
+    const returnedEvents = await service.getAllEvents();
     expect(returnedEvents).toEqual(mockAllEvents);
   });
 
@@ -74,10 +74,10 @@ describe('EventService', () => {
   it('should add the participant to the event', async () => {
     const eventId = 35;
     const userId = 1;
-    const event = await service.event(eventId);
+    const event = await service.getEvent(eventId);
     const oldSize = event.participants.length;
 
-    const updatedEvent = await service.joinEvent(eventId, userId);
+    const updatedEvent = await service.addEventParticipant(eventId, userId);
     expect(updatedEvent.participants.length).toBeGreaterThan(oldSize);
     expect(updatedEvent.participants.pop().id).toEqual(userId);
   });
@@ -85,10 +85,10 @@ describe('EventService', () => {
   it('should remove the participant from the event', async () => {
     const eventId = 35;
     const userId = 3;
-    const event = await service.event(eventId);
+    const event = await service.getEvent(eventId);
     const oldSize = event.participants.length;
 
-    const updatedEvent = await service.leaveEvent(eventId, userId);
+    const updatedEvent = await service.removeEventParticipant(eventId, userId);
     expect(updatedEvent.participants.length).toBeLessThan(oldSize);
   });
 
@@ -96,21 +96,21 @@ describe('EventService', () => {
     const eventId = 35;
     const userId = 150;
     try {
-      await service.leaveEvent(eventId, userId);
+      await service.removeEventParticipant(eventId, userId);
     } catch (error) {
       expect(error).toEqual(new Error('User is not a participant of the event'));
     }
   });
 
   it('should return the event with given id', async () => {
-    const foundEvent = await service.event(35);
+    const foundEvent = await service.getEvent(35);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.id === 35));
   });
 
   it('should return a list of events that belongs to a host', async () => {
     const hostId = mockAllUsers[1].id;
     repository.find.mockReturnValue(mockAllEvents.find((event) => event.host.id === hostId));
-    const foundEvent = await service.hostEvents(hostId);
+    const foundEvent = await service.getEventsHostedByUser(hostId);
     expect(foundEvent).toEqual(mockAllEvents.find((event) => event.host.id === hostId));
     expect(repository.find).toBeCalledTimes(1);
   });
@@ -126,7 +126,7 @@ describe('EventService', () => {
           mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
         ),
     }));
-    const foundEvent = await service.coHostEvents(coHostId);
+    const foundEvent = await service.getEventsCoHostedByUser(coHostId);
     expect(foundEvent).toEqual(
       mockAllEvents.find((event) => event.coHosts.some((cohost) => cohost.id === coHostId))
     );
@@ -146,7 +146,7 @@ describe('EventService', () => {
           )
         ),
     }));
-    const foundEvents = await service.participantEvents(userId);
+    const foundEvents = await service.getEventsAttendedByUser(userId);
     expect(foundEvents).toEqual(
       mockAllEvents.find((event) =>
         event.participants.some((participant) => participant.id === userId)
@@ -163,7 +163,7 @@ describe('EventService', () => {
       andWhere: jest.fn().mockReturnThis(),
       getMany: jest.fn().mockReturnValue(mockAllEvents[2]),
     }));
-    const foundEvents = await service.discoverEvents(userId);
+    const foundEvents = await service.getEventsRecommendedToUser(userId);
     expect(foundEvents).toEqual(mockAllEvents[2]);
     expect(repository.createQueryBuilder).toBeCalledTimes(1);
   });

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -12,15 +12,15 @@ export class EventService {
     private eventRepository: Repository<Event>
   ) {}
 
-  events(): Promise<Event[]> {
+  getAllEvents(): Promise<Event[]> {
     return this.eventRepository.find();
   }
 
-  event(id: number): Promise<Event> {
+  getEvent(id: number): Promise<Event> {
     return this.eventRepository.findOne(id);
   }
 
-  hostEvents(hostId: number): Promise<Event[]> {
+  getEventsHostedByUser(hostId: number): Promise<Event[]> {
     return this.eventRepository.find({
       relations: ['host'],
       where: {
@@ -31,7 +31,7 @@ export class EventService {
     });
   }
 
-  coHostEvents(coHostId: number): Promise<Event[]> {
+  getEventsCoHostedByUser(coHostId: number): Promise<Event[]> {
     return this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.coHosts', 'user')
@@ -39,7 +39,7 @@ export class EventService {
       .getMany();
   }
 
-  participantEvents(userId: number): Promise<Event[]> {
+  getEventsAttendedByUser(userId: number): Promise<Event[]> {
     return this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.participants', 'user')
@@ -51,7 +51,7 @@ export class EventService {
    * Find all the events that the user has not joined, created or is not co-hosting
    * @param userId
    */
-  discoverEvents(userId: number): Promise<Event[]> {
+  getEventsRecommendedToUser(userId: number): Promise<Event[]> {
     return this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.coHosts', 'coHost')
@@ -82,23 +82,23 @@ export class EventService {
 
   async updateEvent(input: UpdateEventInput): Promise<Event> {
     await this.eventRepository.update(input.id, { ...input });
-    return this.event(input.id);
+    return this.getEvent(input.id);
   }
 
   async deleteEvent(id: number): Promise<Event> {
-    const event = await this.event(id);
+    const event = await this.getEvent(id);
     await this.eventRepository.delete(event.id);
     return event;
   }
 
-  async joinEvent(eventId: number, userId: number) {
+  async addEventParticipant(eventId: number, userId: number) {
     const user = new User(userId);
     const event = await this.eventRepository.findOne(eventId, { relations: ['participants'] });
     event.participants.push(user);
     return await this.eventRepository.save(event);
   }
 
-  async leaveEvent(eventId: number, userId: number) {
+  async removeEventParticipant(eventId: number, userId: number) {
     const event = await this.eventRepository.findOne(eventId, { relations: ['participants'] });
     if (event == undefined) {
       throw new Error('Event does not exist');

--- a/apps/mull-api/src/app/media/media.resolver.spec.ts
+++ b/apps/mull-api/src/app/media/media.resolver.spec.ts
@@ -3,7 +3,7 @@ import { createWriteStream, renameSync, unlinkSync } from 'fs';
 import { FileUpload } from 'graphql-upload';
 import { join } from 'path';
 import { Media } from '../entities';
-import { mockFile, mockInvalidFile, mockMedia } from './media.mockdata';
+import { mockFile, mockMedia } from './media.mockdata';
 import { MediaResolver } from './media.resolver';
 import { MediaService } from './media.service';
 
@@ -23,6 +23,12 @@ const mockMediaService = () => ({
           })
       );
     });
+  }),
+  uploadFile: jest.fn(() => {
+    return {
+      id: undefined,
+      mediaType: 'jpeg',
+    };
   }),
   updateFilename: jest.fn(
     (mockPrevFilename: string, mockNextFilename: number, mockFileType: string) => {
@@ -63,11 +69,5 @@ describe('MediaResolver', () => {
   it('should upload a file', async () => {
     const mockUploadedFile = await resolver.uploadFile(mockFile);
     expect(mockUploadedFile).toEqual(mockMedia);
-  });
-
-  it('should not upload an invalid file', async () => {
-    const expectedError = new Error('Internal Server Error');
-    const errorMedia = await resolver.uploadFile(mockInvalidFile);
-    expect(errorMedia).toEqual(expectedError);
   });
 });

--- a/apps/mull-api/src/app/media/media.resolver.ts
+++ b/apps/mull-api/src/app/media/media.resolver.ts
@@ -10,22 +10,9 @@ export class MediaResolver {
 
   @Mutation(/* istanbul ignore next */ () => Media)
   async uploadFile(
-    @Args({ name: 'file', type: /* istanbul ignore next */ () => GraphQLUpload })
+    @Args('file', { type: /* istanbul ignore next */ () => GraphQLUpload })
     file: FileUpload
   ): Promise<Media | Error> {
-    return this.mediaService
-      .saveFile(file)
-      .then(() => {
-        return this.mediaService.create(file.mimetype);
-      })
-      .then((media) => {
-        this.mediaService.updateFilename(file.filename, media.id, media.mediaType);
-        const newMedia = new Media(media.mediaType);
-        newMedia.id = media.id;
-        return newMedia;
-      })
-      .catch(() => {
-        return new Error('Internal Server Error');
-      });
+    return this.mediaService.uploadFile(file);
   }
 }

--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { unlinkSync } from 'fs';
 import { Media } from '../entities';
-import { mockFile, mockInvalidFile } from './media.mockdata';
+import { mockFile, mockInvalidFile, mockMedia } from './media.mockdata';
 import { MediaService } from './media.service';
 
 const mockMediaRepository = () => ({
@@ -38,6 +38,17 @@ describe('MediaService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should upload a file', async () => {
+    const mockUploadedFile = await service.uploadFile(mockFile);
+    expect(mockUploadedFile).toEqual(mockMedia);
+  });
+
+  it('should not upload an invalid file', async () => {
+    const expectedError = new Error('Internal Server Error');
+    const errorMedia = await service.uploadFile(mockInvalidFile);
+    expect(errorMedia).toEqual(expectedError);
   });
 
   it('should create media', async () => {

--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -41,7 +41,7 @@ describe('MediaService', () => {
   });
 
   it('should create media', async () => {
-    const returnedMedia = await service.create(mockFile.mimetype);
+    const returnedMedia = await service.createMedia(mockFile.mimetype);
     expect(returnedMedia.mediaType).toEqual(mockFile.mimetype.split('/')[1]);
   });
 

--- a/apps/mull-api/src/app/media/media.service.ts
+++ b/apps/mull-api/src/app/media/media.service.ts
@@ -13,6 +13,18 @@ export class MediaService {
     private mediaRepository: Repository<Media>
   ) {}
 
+  async uploadFile(file: FileUpload): Promise<Media | Error> {
+    try {
+      await this.saveFile(file);
+      var media = await this.createMedia(file.mimetype);
+      this.updateFilename(file.filename, media.id, media.mediaType);
+    } catch (err) {
+      return new Error('Internal Server Error');
+    }
+
+    return media;
+  }
+
   saveFile({ createReadStream, filename }: FileUpload): Promise<boolean> {
     return new Promise((resolve, reject) => {
       createReadStream().pipe(

--- a/apps/mull-api/src/app/media/media.service.ts
+++ b/apps/mull-api/src/app/media/media.service.ts
@@ -25,7 +25,7 @@ export class MediaService {
     });
   }
 
-  async create(mediaType: string): Promise<Media> {
+  async createMedia(mediaType: string): Promise<Media> {
     const fileType = mediaType.split('/')[1];
     const newMedia = new Media(fileType);
     return await this.mediaRepository.save(newMedia);

--- a/apps/mull-api/src/app/user/user.mockdata.ts
+++ b/apps/mull-api/src/app/user/user.mockdata.ts
@@ -1,8 +1,8 @@
 import { RegistrationMethod } from '@mull/types';
 import { User } from '../entities';
-import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
+import { CreateUserInput } from './inputs/user.input';
 
-export const mockPartialUser: CreateUserInput | UpdateUserInput = {
+export const mockPartialUser: Partial<User> = {
   password: 'password',
   email: 'mock@mock.com',
   dob: new Date(),

--- a/apps/mull-api/src/app/user/user.resolver.spec.ts
+++ b/apps/mull-api/src/app/user/user.resolver.spec.ts
@@ -8,14 +8,14 @@ import { UserService } from './user.service';
 
 const mockUserService = () => ({
   createUser: jest.fn((mockUserData: CreateUserInput) => ({ ...mockUserData })),
-  user: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
-  users: jest.fn(() => mockAllUsers),
+  getUser: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
+  getAllUsers: jest.fn(() => mockAllUsers),
   findUnique: jest.fn((email: string, registrationMethod: RegistrationMethod) => {
     return Promise.resolve(
       mockAllUsers.filter((u) => u.email === email && u.registrationMethod === registrationMethod)
     );
   }),
-  friends: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id).friends),
+  getFriends: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id).friends),
   updateUser: jest.fn((mockUserData: UpdateUserInput) => ({ ...mockUserData })),
   deleteUser: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
 });

--- a/apps/mull-api/src/app/user/user.resolver.spec.ts
+++ b/apps/mull-api/src/app/user/user.resolver.spec.ts
@@ -7,17 +7,17 @@ import { UserResolver } from './user.resolver';
 import { UserService } from './user.service';
 
 const mockUserService = () => ({
-  create: jest.fn((mockUserData: CreateUserInput) => ({ ...mockUserData })),
-  findOne: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
-  findAll: jest.fn(() => mockAllUsers),
+  createUser: jest.fn((mockUserData: CreateUserInput) => ({ ...mockUserData })),
+  user: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
+  users: jest.fn(() => mockAllUsers),
   findUnique: jest.fn((email: string, registrationMethod: RegistrationMethod) => {
     return Promise.resolve(
       mockAllUsers.filter((u) => u.email === email && u.registrationMethod === registrationMethod)
     );
   }),
-  findAllFriends: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id).friends),
+  friends: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id).friends),
   updateUser: jest.fn((mockUserData: UpdateUserInput) => ({ ...mockUserData })),
-  delete: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
+  deleteUser: jest.fn((id: number) => mockAllUsers.find((user) => user.id === id)),
 });
 
 describe('UserResolver', () => {
@@ -38,9 +38,7 @@ describe('UserResolver', () => {
 
   it('should create a local user', async () => {
     const returnedUser = await resolver.createUser({ ...mockNewPartialUser });
-    expect(returnedUser.name).toEqual(mockNewPartialUser.name);
-    expect(returnedUser.email).toEqual(mockNewPartialUser.email);
-    expect(returnedUser.password).not.toEqual(mockNewPartialUser.password);
+    expect(returnedUser).toEqual(mockNewPartialUser);
   });
 
   it('should not create a local user', async () => {

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -1,7 +1,4 @@
-import { RegistrationMethod } from '@mull/types';
-import { UnauthorizedException } from '@nestjs/common';
 import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { genSalt, hash } from 'bcrypt';
 import { User } from '../entities';
 import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
 import { UserService } from './user.service';
@@ -28,14 +25,6 @@ export class UserResolver {
 
   @Mutation(/* istanbul ignore next */ () => User)
   async createUser(@Args('input') input: CreateUserInput) {
-    if (input.registrationMethod === RegistrationMethod.LOCAL) {
-      const salt = await genSalt(10);
-      const hashed = await hash(input.password, salt);
-      input.password = hashed;
-    }
-    const existingUser = await this.userService.findUnique(input.email, input.registrationMethod);
-    if (existingUser.length > 0)
-      throw new UnauthorizedException('User with this email already exists.');
     return this.userService.createUser(input);
   }
 

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -12,43 +12,40 @@ export class UserResolver {
 
   @Query(/* istanbul ignore next */ () => [User])
   async users() {
-    return this.userService.findAll();
+    return this.userService.users();
   }
 
   @Query(/* istanbul ignore next */ () => User)
   async user(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.userService.findOne(id);
+    return this.userService.user(id);
   }
 
   @ResolveField(/* istanbul ignore next */ () => [User])
   async friends(@Parent() user: User) {
     const { id } = user;
-    return this.userService.findAllFriends(id);
+    return this.userService.friends(id);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  async createUser(@Args('createUserInput') createUserInput: CreateUserInput) {
-    if (createUserInput.registrationMethod === RegistrationMethod.LOCAL) {
+  async createUser(@Args('input') input: CreateUserInput) {
+    if (input.registrationMethod === RegistrationMethod.LOCAL) {
       const salt = await genSalt(10);
-      const hashed = await hash(createUserInput.password, salt);
-      createUserInput.password = hashed;
+      const hashed = await hash(input.password, salt);
+      input.password = hashed;
     }
-    const existingUser = await this.userService.findUnique(
-      createUserInput.email,
-      createUserInput.registrationMethod
-    );
+    const existingUser = await this.userService.findUnique(input.email, input.registrationMethod);
     if (existingUser.length > 0)
       throw new UnauthorizedException('User with this email already exists.');
-    return this.userService.create(createUserInput);
+    return this.userService.createUser(input);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  async updateUser(@Args('updateUserInput') updateUserInput: UpdateUserInput) {
-    return this.userService.updateUser(updateUserInput);
+  async updateUser(@Args('input') input: UpdateUserInput) {
+    return this.userService.updateUser(input);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
   async deleteUser(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.userService.delete(id);
+    return this.userService.deleteUser(id);
   }
 }

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -9,28 +9,28 @@ export class UserResolver {
 
   @Query(/* istanbul ignore next */ () => [User])
   async users() {
-    return this.userService.users();
+    return this.userService.getAllUsers();
   }
 
   @Query(/* istanbul ignore next */ () => User)
   async user(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
-    return this.userService.user(id);
+    return this.userService.getUser(id);
   }
 
   @ResolveField(/* istanbul ignore next */ () => [User])
   async friends(@Parent() user: User) {
     const { id } = user;
-    return this.userService.friends(id);
+    return this.userService.getFriends(id);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  async createUser(@Args('input') input: CreateUserInput) {
-    return this.userService.createUser(input);
+  async createUser(@Args('user') user: CreateUserInput) {
+    return this.userService.createUser(user);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  async updateUser(@Args('input') input: UpdateUserInput) {
-    return this.userService.updateUser(input);
+  async updateUser(@Args('user') user: UpdateUserInput) {
+    return this.userService.updateUser(user);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)

--- a/apps/mull-api/src/app/user/user.service.spec.ts
+++ b/apps/mull-api/src/app/user/user.service.spec.ts
@@ -63,7 +63,7 @@ describe('UserService', () => {
   });
 
   it('should fetch all users', async () => {
-    const returnedUsers = await service.users();
+    const returnedUsers = await service.getAllUsers();
     expect(returnedUsers).toEqual(mockAllUsers);
   });
 
@@ -83,7 +83,7 @@ describe('UserService', () => {
   });
 
   it('should fetch all friends of mockUser 1', async () => {
-    const returnedUserFriends = await service.friends(1);
+    const returnedUserFriends = await service.getFriends(1);
     expect(returnedUserFriends).toEqual(mockAllUsers.find((user) => user.id === 1).friends);
   });
 
@@ -98,7 +98,7 @@ describe('UserService', () => {
   });
 
   it('should return the user with given id', async () => {
-    const foundUser = await service.user(1);
+    const foundUser = await service.getUser(1);
     expect(foundUser).toEqual(mockAllUsers.find((user) => user.id === 1));
   });
 

--- a/apps/mull-api/src/app/user/user.service.spec.ts
+++ b/apps/mull-api/src/app/user/user.service.spec.ts
@@ -49,12 +49,12 @@ describe('UserService', () => {
   });
 
   it('should create user', async () => {
-    const returnedUser = await service.create(mockPartialUser as CreateUserInput);
+    const returnedUser = await service.createUser(mockPartialUser as CreateUserInput);
     expect(returnedUser).toEqual(mockPartialUser);
   });
 
   it('should fetch all users', async () => {
-    const returnedUsers = await service.findAll();
+    const returnedUsers = await service.users();
     expect(returnedUsers).toEqual(mockAllUsers);
   });
 
@@ -74,7 +74,7 @@ describe('UserService', () => {
   });
 
   it('should fetch all friends of mockUser 1', async () => {
-    const returnedUserFriends = await service.findAllFriends(1);
+    const returnedUserFriends = await service.friends(1);
     expect(returnedUserFriends).toEqual(mockAllUsers.find((user) => user.id === 1).friends);
   });
 
@@ -84,12 +84,12 @@ describe('UserService', () => {
   });
 
   it('should return the deleted user', async () => {
-    const deletedUser = await service.delete(1);
+    const deletedUser = await service.deleteUser(1);
     expect(deletedUser).toEqual(mockAllUsers.find((user) => user.id === 1));
   });
 
   it('should return the user with given id', async () => {
-    const foundUser = await service.findOne(1);
+    const foundUser = await service.user(1);
     expect(foundUser).toEqual(mockAllUsers.find((user) => user.id === 1));
   });
 

--- a/apps/mull-api/src/app/user/user.service.ts
+++ b/apps/mull-api/src/app/user/user.service.ts
@@ -13,11 +13,11 @@ export class UserService {
     private userRepository: Repository<User>
   ) {}
 
-  users(): Promise<User[]> {
+  getAllUsers(): Promise<User[]> {
     return this.userRepository.find();
   }
 
-  user(id: number): Promise<User> {
+  getUser(id: number): Promise<User> {
     return this.userRepository.findOne(id);
   }
 
@@ -29,7 +29,7 @@ export class UserService {
     return this.userRepository.find({ where: { email, registrationMethod } });
   }
 
-  async friends(userId: number): Promise<User[]> {
+  async getFriends(userId: number): Promise<User[]> {
     const { friends } = await this.userRepository.findOne(userId, { relations: ['friends'] });
     return friends;
   }
@@ -48,11 +48,11 @@ export class UserService {
 
   async updateUser(userInput: UpdateUserInput): Promise<User> {
     await this.userRepository.update(userInput.id, { ...userInput });
-    return this.user(userInput.id);
+    return this.getUser(userInput.id);
   }
 
   async deleteUser(id: number): Promise<User> {
-    const user = await this.user(id);
+    const user = await this.getUser(id);
     await this.userRepository.delete(user.id);
     return user;
   }

--- a/apps/mull-api/src/app/user/user.service.ts
+++ b/apps/mull-api/src/app/user/user.service.ts
@@ -12,11 +12,11 @@ export class UserService {
     private userRepository: Repository<User>
   ) {}
 
-  findAll(): Promise<User[]> {
+  users(): Promise<User[]> {
     return this.userRepository.find();
   }
 
-  findOne(id: number): Promise<User> {
+  user(id: number): Promise<User> {
     return this.userRepository.findOne(id);
   }
 
@@ -28,22 +28,22 @@ export class UserService {
     return this.userRepository.find({ where: { email, registrationMethod } });
   }
 
-  async findAllFriends(id: number): Promise<User[]> {
-    const { friends } = await this.userRepository.findOne(id, { relations: ['friends'] });
+  async friends(userId: number): Promise<User[]> {
+    const { friends } = await this.userRepository.findOne(userId, { relations: ['friends'] });
     return friends;
   }
 
-  async create(userInput: CreateUserInput): Promise<User> {
+  async createUser(userInput: CreateUserInput): Promise<User> {
     return await this.userRepository.save({ ...userInput });
   }
 
   async updateUser(userInput: UpdateUserInput): Promise<User> {
     await this.userRepository.update(userInput.id, { ...userInput });
-    return this.findOne(userInput.id);
+    return this.user(userInput.id);
   }
 
-  async delete(id: number): Promise<User> {
-    const user = await this.findOne(id);
+  async deleteUser(id: number): Promise<User> {
+    const user = await this.user(id);
     await this.userRepository.delete(user.id);
     return user;
   }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -54,25 +54,25 @@ input MediaInput {
 }
 
 type Mutation {
-  addParticipantToEvent(eventId: Float!, userId: Float!): Boolean!
-  createEvent(createEventInput: CreateEventInput!): Event!
-  createUser(createUserInput: CreateUserInput!): User!
+  createEvent(input: CreateEventInput!): Event!
+  createUser(input: CreateUserInput!): User!
   deleteEvent(id: Int!): Event!
   deleteUser(id: Int!): User!
+  joinEvent(eventId: Float!, userId: Float!): Boolean!
+  leaveEvent(eventId: Float!, userId: Float!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
-  removeParticipantFromEvent(eventId: Float!, userId: Float!): Boolean!
-  updateEvent(updateEventInput: UpdateEventInput!): Event!
-  updateUser(updateUserInput: UpdateUserInput!): User!
+  updateEvent(input: UpdateEventInput!): Event!
+  updateUser(input: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!
 }
 
 type Query {
-  coHostEvents(userId: Int!): [Event!]!
+  coHostEvents(coHostId: Int!): [Event!]!
   discoverEvents(userId: Int!): [Event!]!
   event(id: Int!): Event!
   events: [Event!]!
-  hostEvents(userId: Int!): [Event!]!
-  participatingEvents(userId: Int!): [Event!]!
+  hostEvents(hostId: Int!): [Event!]!
+  participantEvents(userId: Int!): [Event!]!
   user(id: Int!): User!
   users: [User!]!
 }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -54,15 +54,15 @@ input MediaInput {
 }
 
 type Mutation {
-  createEvent(input: CreateEventInput!): Event!
-  createUser(input: CreateUserInput!): User!
+  createEvent(event: CreateEventInput!): Event!
+  createUser(user: CreateUserInput!): User!
   deleteEvent(id: Int!): Event!
   deleteUser(id: Int!): User!
   joinEvent(eventId: Float!, userId: Float!): Boolean!
   leaveEvent(eventId: Float!, userId: Float!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
-  updateEvent(input: UpdateEventInput!): Event!
-  updateUser(input: UpdateUserInput!): User!
+  updateEvent(event: UpdateEventInput!): Event!
+  updateUser(user: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!
 }
 

--- a/apps/mull-ui/.eslintrc
+++ b/apps/mull-ui/.eslintrc
@@ -239,5 +239,5 @@
   "settings": { "react": { "version": "detect" } },
   "plugins": ["import", "jsx-a11y", "react", "react-hooks"],
   "extends": ["../../.eslintrc"],
-  "ignorePatterns": ["!**/*"]
+  "ignorePatterns": ["!**/*", "graphql.tsx"]
 }

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -107,7 +107,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
         } = await uploadFile({ variables: { file: file } });
         await createEvent({
           variables: {
-            createEventInput: {
+            input: {
               ...payload,
               image: { id: uploadedFile.id, mediaType: uploadedFile.mediaType },
             } as CreateEventInput,

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -107,7 +107,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
         } = await uploadFile({ variables: { file: file } });
         await createEvent({
           variables: {
-            input: {
+            event: {
               ...payload,
               image: { id: uploadedFile.id, mediaType: uploadedFile.mediaType },
             } as CreateEventInput,

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { CreateEventInput, useFindSpecificEventQuery } from '../../../generated/graphql';
+import { CreateEventInput, useEventQuery } from '../../../generated/graphql';
 import { EventPageHeader, EventPageInfo } from '../../components';
 import './event-page.scss';
 
@@ -26,8 +26,8 @@ export const EventPage = ({
   const { id } = useParams<{ id: string }>();
   const eventId = parseInt(id);
 
-  const { loading, error, data } = useFindSpecificEventQuery({
-    variables: { eventId },
+  const { loading, error, data } = useEventQuery({
+    variables: { id: eventId },
     skip: !!event,
   });
 

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.spec.tsx
@@ -16,7 +16,7 @@ describe('discoverPage', () => {
     const { baseElement } = render(
       <MockedProvider>
         <Router history={history}>
-          <DiscoverPage />
+          <DiscoverPage history={history} />
         </Router>
       </MockedProvider>
     );
@@ -29,7 +29,7 @@ describe('discoverPage', () => {
         {
           request: {
             query: DiscoverEventsDocument,
-            variables: { discoverEventsUserId: 1 },
+            variables: { userId: 1 },
           },
           result: {
             data: {
@@ -54,7 +54,7 @@ describe('discoverPage', () => {
       const utils = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <Router history={history}>
-            <DiscoverPage />
+            <DiscoverPage history={history} />
           </Router>
         </MockedProvider>
       );

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -8,7 +8,7 @@ export const DiscoverPage = ({ history }) => {
   const { data } = useDiscoverEventsQuery({
     fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
-    variables: { discoverEventsUserId: 1 },
+    variables: { userId: 1 },
   });
 
   if (data) {

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.spec.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { ROUTES } from '../../../../constants';
-import { GetUsersEventsDocument } from '../../../../generated/graphql';
+import { OwnedEventsDocument } from '../../../../generated/graphql';
 import MyEventsPage from './my-events';
 
 describe('myEventsPage', () => {
@@ -16,7 +16,7 @@ describe('myEventsPage', () => {
     const { baseElement } = render(
       <MockedProvider>
         <Router history={history}>
-          <MyEventsPage />
+          <MyEventsPage history={history} />
         </Router>
       </MockedProvider>
     );
@@ -27,8 +27,8 @@ describe('myEventsPage', () => {
       const mocks: MockedResponse[] = [
         {
           request: {
-            query: GetUsersEventsDocument,
-            variables: { UserId: 1 },
+            query: OwnedEventsDocument,
+            variables: { userId: 1 },
           },
           result: {
             data: {
@@ -63,7 +63,7 @@ describe('myEventsPage', () => {
       const utils = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <Router history={history}>
-            <MyEventsPage />
+            <MyEventsPage history={history} />
           </Router>
         </MockedProvider>
       );

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -1,14 +1,14 @@
 import { ISerializedEvent } from '@mull/types';
 import React from 'react';
-import { useGetUsersEventsQuery } from '../../../../generated/graphql';
+import { useOwnedEventsQuery } from '../../../../generated/graphql';
 import { EventCard } from '../../../components';
 import '../home-discover.scss';
 
 export const MyEventsPage = ({ history }) => {
-  const { data } = useGetUsersEventsQuery({
+  const { data } = useOwnedEventsQuery({
     fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
-    variables: { UserId: 1 },
+    variables: { userId: 1 },
   });
 
   if (data) {

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.spec.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { ROUTES } from '../../../../constants';
-import { GetParticipatingEventsDocument } from '../../../../generated/graphql';
+import { ParticipantEventsDocument } from '../../../../generated/graphql';
 import UpcomingPage from './upcoming';
 
 describe('myEventsPage', () => {
@@ -16,7 +16,7 @@ describe('myEventsPage', () => {
     const { baseElement } = render(
       <MockedProvider>
         <Router history={history}>
-          <UpcomingPage />
+          <UpcomingPage history={history} />
         </Router>
       </MockedProvider>
     );
@@ -28,12 +28,12 @@ describe('myEventsPage', () => {
       const mocks: MockedResponse[] = [
         {
           request: {
-            query: GetParticipatingEventsDocument,
-            variables: { participatingEventsUserId: 1 },
+            query: ParticipantEventsDocument,
+            variables: { userId: 1 },
           },
           result: {
             data: {
-              participatingEvents: [
+              participantEvents: [
                 {
                   id: '1',
                   title: 'test',
@@ -54,7 +54,7 @@ describe('myEventsPage', () => {
       const utils = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <Router history={history}>
-            <UpcomingPage />
+            <UpcomingPage history={history} />
           </Router>
         </MockedProvider>
       );

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -1,18 +1,18 @@
 import { ISerializedEvent } from '@mull/types';
 import React from 'react';
-import { useGetParticipatingEventsQuery } from '../../../../generated/graphql';
+import { useParticipantEventsQuery } from '../../../../generated/graphql';
 import { EventCard } from '../../../components';
 import '../home-discover.scss';
 
 export const UpcomingPage = ({ history }) => {
-  const { data } = useGetParticipatingEventsQuery({
+  const { data } = useParticipantEventsQuery({
     fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
-    variables: { participatingEventsUserId: 1 },
+    variables: { userId: 1 },
   });
 
   if (data) {
-    const events = (data.participatingEvents as unknown) as Partial<ISerializedEvent>[];
+    const events = (data.participantEvents as unknown) as Partial<ISerializedEvent>[];
     var eventCards = events.map((event, index) => (
       <EventCard key={index} event={event} onClick={() => history.push(`/events/${event.id}`)} />
     ));

--- a/apps/mull-ui/src/app/pages/register/register.spec.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.spec.tsx
@@ -59,7 +59,7 @@ describe('Register', () => {
         request: {
           query: CreateUserDocument,
           variables: {
-            createUserInput: {
+            user: {
               name: 'John Doe',
               email: 'abc@def.com',
               password: 'abc123',

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -36,10 +36,10 @@ const Register = ({ history }: RegisterProps) => {
 
     onSubmit: async (values) => {
       notifyToast('Registering new user...');
-      const input = { ...values, registrationMethod: RegistrationMethod.Local };
+      const user = { ...values, registrationMethod: RegistrationMethod.Local };
 
       try {
-        var { errors } = await createUser({ variables: { input } });
+        var { errors } = await createUser({ variables: { user } });
       } catch (err) {
         updateToast(toast.TYPE.ERROR, err.message);
         return;

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -36,10 +36,10 @@ const Register = ({ history }: RegisterProps) => {
 
     onSubmit: async (values) => {
       notifyToast('Registering new user...');
-      const createUserInput = { ...values, registrationMethod: RegistrationMethod.Local };
+      const input = { ...values, registrationMethod: RegistrationMethod.Local };
 
       try {
-        var { errors } = await createUser({ variables: { createUserInput } });
+        var { errors } = await createUser({ variables: { input } });
       } catch (err) {
         updateToast(toast.TYPE.ERROR, err.message);
         return;

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -69,32 +69,26 @@ export type MediaInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  addParticipantToEvent: Scalars['Boolean'];
   createEvent: Event;
   createUser: User;
   deleteEvent: Event;
   deleteUser: User;
+  joinEvent: Scalars['Boolean'];
+  leaveEvent: Scalars['Boolean'];
   login: LoginResult;
-  removeParticipantFromEvent: Scalars['Boolean'];
   updateEvent: Event;
   updateUser: User;
   uploadFile: Media;
 };
 
 
-export type MutationAddParticipantToEventArgs = {
-  eventId: Scalars['Float'];
-  userId: Scalars['Float'];
-};
-
-
 export type MutationCreateEventArgs = {
-  createEventInput: CreateEventInput;
+  input: CreateEventInput;
 };
 
 
 export type MutationCreateUserArgs = {
-  createUserInput: CreateUserInput;
+  input: CreateUserInput;
 };
 
 
@@ -108,24 +102,30 @@ export type MutationDeleteUserArgs = {
 };
 
 
-export type MutationLoginArgs = {
-  loginInput: LoginInput;
-};
-
-
-export type MutationRemoveParticipantFromEventArgs = {
+export type MutationJoinEventArgs = {
   eventId: Scalars['Float'];
   userId: Scalars['Float'];
 };
 
 
+export type MutationLeaveEventArgs = {
+  eventId: Scalars['Float'];
+  userId: Scalars['Float'];
+};
+
+
+export type MutationLoginArgs = {
+  loginInput: LoginInput;
+};
+
+
 export type MutationUpdateEventArgs = {
-  updateEventInput: UpdateEventInput;
+  input: UpdateEventInput;
 };
 
 
 export type MutationUpdateUserArgs = {
-  updateUserInput: UpdateUserInput;
+  input: UpdateUserInput;
 };
 
 
@@ -140,14 +140,14 @@ export type Query = {
   event: Event;
   events: Array<Event>;
   hostEvents: Array<Event>;
-  participatingEvents: Array<Event>;
+  participantEvents: Array<Event>;
   user: User;
   users: Array<User>;
 };
 
 
 export type QueryCoHostEventsArgs = {
-  userId: Scalars['Int'];
+  coHostId: Scalars['Int'];
 };
 
 
@@ -162,11 +162,11 @@ export type QueryEventArgs = {
 
 
 export type QueryHostEventsArgs = {
-  userId: Scalars['Int'];
+  hostId: Scalars['Int'];
 };
 
 
-export type QueryParticipatingEventsArgs = {
+export type QueryParticipantEventsArgs = {
   userId: Scalars['Int'];
 };
 
@@ -213,7 +213,7 @@ export type User = {
 };
 
 export type CreateEventMutationVariables = Exact<{
-  createEventInput: CreateEventInput;
+  input: CreateEventInput;
 }>;
 
 
@@ -239,7 +239,7 @@ export type UploadFileMutation = (
 );
 
 export type CreateUserMutationVariables = Exact<{
-  createUserInput: CreateUserInput;
+  input: CreateUserInput;
 }>;
 
 
@@ -264,12 +264,12 @@ export type LoginMutation = (
   ) }
 );
 
-export type FindSpecificEventQueryVariables = Exact<{
-  eventId: Scalars['Int'];
+export type EventQueryVariables = Exact<{
+  id: Scalars['Int'];
 }>;
 
 
-export type FindSpecificEventQuery = (
+export type EventQuery = (
   { __typename?: 'Query' }
   & { event: (
     { __typename?: 'Event' }
@@ -278,7 +278,7 @@ export type FindSpecificEventQuery = (
 );
 
 export type DiscoverEventsQueryVariables = Exact<{
-  discoverEventsUserId: Scalars['Int'];
+  userId: Scalars['Int'];
 }>;
 
 
@@ -290,12 +290,12 @@ export type DiscoverEventsQuery = (
   )> }
 );
 
-export type GetUsersEventsQueryVariables = Exact<{
-  UserId: Scalars['Int'];
+export type OwnedEventsQueryVariables = Exact<{
+  userId: Scalars['Int'];
 }>;
 
 
-export type GetUsersEventsQuery = (
+export type OwnedEventsQuery = (
   { __typename?: 'Query' }
   & { coHostEvents: Array<(
     { __typename?: 'Event' }
@@ -306,14 +306,14 @@ export type GetUsersEventsQuery = (
   )> }
 );
 
-export type GetParticipatingEventsQueryVariables = Exact<{
-  participatingEventsUserId: Scalars['Int'];
+export type ParticipantEventsQueryVariables = Exact<{
+  userId: Scalars['Int'];
 }>;
 
 
-export type GetParticipatingEventsQuery = (
+export type ParticipantEventsQuery = (
   { __typename?: 'Query' }
-  & { participatingEvents: Array<(
+  & { participantEvents: Array<(
     { __typename?: 'Event' }
     & Pick<Event, 'id' | 'endDate' | 'description' | 'startDate' | 'title'>
   )> }
@@ -321,8 +321,8 @@ export type GetParticipatingEventsQuery = (
 
 
 export const CreateEventDocument = gql`
-    mutation CreateEvent($createEventInput: CreateEventInput!) {
-  createEvent(createEventInput: $createEventInput) {
+    mutation CreateEvent($input: CreateEventInput!) {
+  createEvent(input: $input) {
     id
   }
 }
@@ -342,7 +342,7 @@ export type CreateEventMutationFn = Apollo.MutationFunction<CreateEventMutation,
  * @example
  * const [createEventMutation, { data, loading, error }] = useCreateEventMutation({
  *   variables: {
- *      createEventInput: // value for 'createEventInput'
+ *      input: // value for 'input'
  *   },
  * });
  */
@@ -386,8 +386,8 @@ export type UploadFileMutationHookResult = ReturnType<typeof useUploadFileMutati
 export type UploadFileMutationResult = Apollo.MutationResult<UploadFileMutation>;
 export type UploadFileMutationOptions = Apollo.BaseMutationOptions<UploadFileMutation, UploadFileMutationVariables>;
 export const CreateUserDocument = gql`
-    mutation CreateUser($createUserInput: CreateUserInput!) {
-  createUser(createUserInput: $createUserInput) {
+    mutation CreateUser($input: CreateUserInput!) {
+  createUser(input: $input) {
     id
   }
 }
@@ -407,7 +407,7 @@ export type CreateUserMutationFn = Apollo.MutationFunction<CreateUserMutation, C
  * @example
  * const [createUserMutation, { data, loading, error }] = useCreateUserMutation({
  *   variables: {
- *      createUserInput: // value for 'createUserInput'
+ *      input: // value for 'input'
  *   },
  * });
  */
@@ -449,9 +449,9 @@ export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginM
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
-export const FindSpecificEventDocument = gql`
-    query FindSpecificEvent($eventId: Int!) {
-  event(id: $eventId) {
+export const EventDocument = gql`
+    query Event($id: Int!) {
+  event(id: $id) {
     id
     title
     description
@@ -463,33 +463,33 @@ export const FindSpecificEventDocument = gql`
     `;
 
 /**
- * __useFindSpecificEventQuery__
+ * __useEventQuery__
  *
- * To run a query within a React component, call `useFindSpecificEventQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindSpecificEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useFindSpecificEventQuery({
+ * const { data, loading, error } = useEventQuery({
  *   variables: {
- *      eventId: // value for 'eventId'
+ *      id: // value for 'id'
  *   },
  * });
  */
-export function useFindSpecificEventQuery(baseOptions: Apollo.QueryHookOptions<FindSpecificEventQuery, FindSpecificEventQueryVariables>) {
-        return Apollo.useQuery<FindSpecificEventQuery, FindSpecificEventQueryVariables>(FindSpecificEventDocument, baseOptions);
+export function useEventQuery(baseOptions: Apollo.QueryHookOptions<EventQuery, EventQueryVariables>) {
+        return Apollo.useQuery<EventQuery, EventQueryVariables>(EventDocument, baseOptions);
       }
-export function useFindSpecificEventLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindSpecificEventQuery, FindSpecificEventQueryVariables>) {
-          return Apollo.useLazyQuery<FindSpecificEventQuery, FindSpecificEventQueryVariables>(FindSpecificEventDocument, baseOptions);
+export function useEventLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventQuery, EventQueryVariables>) {
+          return Apollo.useLazyQuery<EventQuery, EventQueryVariables>(EventDocument, baseOptions);
         }
-export type FindSpecificEventQueryHookResult = ReturnType<typeof useFindSpecificEventQuery>;
-export type FindSpecificEventLazyQueryHookResult = ReturnType<typeof useFindSpecificEventLazyQuery>;
-export type FindSpecificEventQueryResult = Apollo.QueryResult<FindSpecificEventQuery, FindSpecificEventQueryVariables>;
+export type EventQueryHookResult = ReturnType<typeof useEventQuery>;
+export type EventLazyQueryHookResult = ReturnType<typeof useEventLazyQuery>;
+export type EventQueryResult = Apollo.QueryResult<EventQuery, EventQueryVariables>;
 export const DiscoverEventsDocument = gql`
-    query DiscoverEvents($discoverEventsUserId: Int!) {
-  discoverEvents(userId: $discoverEventsUserId) {
+    query DiscoverEvents($userId: Int!) {
+  discoverEvents(userId: $userId) {
     id
     title
     description
@@ -511,7 +511,7 @@ export const DiscoverEventsDocument = gql`
  * @example
  * const { data, loading, error } = useDiscoverEventsQuery({
  *   variables: {
- *      discoverEventsUserId: // value for 'discoverEventsUserId'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -524,16 +524,16 @@ export function useDiscoverEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type DiscoverEventsQueryHookResult = ReturnType<typeof useDiscoverEventsQuery>;
 export type DiscoverEventsLazyQueryHookResult = ReturnType<typeof useDiscoverEventsLazyQuery>;
 export type DiscoverEventsQueryResult = Apollo.QueryResult<DiscoverEventsQuery, DiscoverEventsQueryVariables>;
-export const GetUsersEventsDocument = gql`
-    query GetUsersEvents($UserId: Int!) {
-  coHostEvents(userId: $UserId) {
+export const OwnedEventsDocument = gql`
+    query OwnedEvents($userId: Int!) {
+  coHostEvents(coHostId: $userId) {
     id
     title
     description
     startDate
     endDate
   }
-  hostEvents(userId: $UserId) {
+  hostEvents(hostId: $userId) {
     id
     title
     description
@@ -544,33 +544,33 @@ export const GetUsersEventsDocument = gql`
     `;
 
 /**
- * __useGetUsersEventsQuery__
+ * __useOwnedEventsQuery__
  *
- * To run a query within a React component, call `useGetUsersEventsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUsersEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOwnedEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOwnedEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetUsersEventsQuery({
+ * const { data, loading, error } = useOwnedEventsQuery({
  *   variables: {
- *      UserId: // value for 'UserId'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useGetUsersEventsQuery(baseOptions: Apollo.QueryHookOptions<GetUsersEventsQuery, GetUsersEventsQueryVariables>) {
-        return Apollo.useQuery<GetUsersEventsQuery, GetUsersEventsQueryVariables>(GetUsersEventsDocument, baseOptions);
+export function useOwnedEventsQuery(baseOptions: Apollo.QueryHookOptions<OwnedEventsQuery, OwnedEventsQueryVariables>) {
+        return Apollo.useQuery<OwnedEventsQuery, OwnedEventsQueryVariables>(OwnedEventsDocument, baseOptions);
       }
-export function useGetUsersEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetUsersEventsQuery, GetUsersEventsQueryVariables>) {
-          return Apollo.useLazyQuery<GetUsersEventsQuery, GetUsersEventsQueryVariables>(GetUsersEventsDocument, baseOptions);
+export function useOwnedEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OwnedEventsQuery, OwnedEventsQueryVariables>) {
+          return Apollo.useLazyQuery<OwnedEventsQuery, OwnedEventsQueryVariables>(OwnedEventsDocument, baseOptions);
         }
-export type GetUsersEventsQueryHookResult = ReturnType<typeof useGetUsersEventsQuery>;
-export type GetUsersEventsLazyQueryHookResult = ReturnType<typeof useGetUsersEventsLazyQuery>;
-export type GetUsersEventsQueryResult = Apollo.QueryResult<GetUsersEventsQuery, GetUsersEventsQueryVariables>;
-export const GetParticipatingEventsDocument = gql`
-    query GetParticipatingEvents($participatingEventsUserId: Int!) {
-  participatingEvents(userId: $participatingEventsUserId) {
+export type OwnedEventsQueryHookResult = ReturnType<typeof useOwnedEventsQuery>;
+export type OwnedEventsLazyQueryHookResult = ReturnType<typeof useOwnedEventsLazyQuery>;
+export type OwnedEventsQueryResult = Apollo.QueryResult<OwnedEventsQuery, OwnedEventsQueryVariables>;
+export const ParticipantEventsDocument = gql`
+    query ParticipantEvents($userId: Int!) {
+  participantEvents(userId: $userId) {
     id
     endDate
     description
@@ -581,27 +581,27 @@ export const GetParticipatingEventsDocument = gql`
     `;
 
 /**
- * __useGetParticipatingEventsQuery__
+ * __useParticipantEventsQuery__
  *
- * To run a query within a React component, call `useGetParticipatingEventsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetParticipatingEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useParticipantEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useParticipantEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetParticipatingEventsQuery({
+ * const { data, loading, error } = useParticipantEventsQuery({
  *   variables: {
- *      participatingEventsUserId: // value for 'participatingEventsUserId'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useGetParticipatingEventsQuery(baseOptions: Apollo.QueryHookOptions<GetParticipatingEventsQuery, GetParticipatingEventsQueryVariables>) {
-        return Apollo.useQuery<GetParticipatingEventsQuery, GetParticipatingEventsQueryVariables>(GetParticipatingEventsDocument, baseOptions);
+export function useParticipantEventsQuery(baseOptions: Apollo.QueryHookOptions<ParticipantEventsQuery, ParticipantEventsQueryVariables>) {
+        return Apollo.useQuery<ParticipantEventsQuery, ParticipantEventsQueryVariables>(ParticipantEventsDocument, baseOptions);
       }
-export function useGetParticipatingEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetParticipatingEventsQuery, GetParticipatingEventsQueryVariables>) {
-          return Apollo.useLazyQuery<GetParticipatingEventsQuery, GetParticipatingEventsQueryVariables>(GetParticipatingEventsDocument, baseOptions);
+export function useParticipantEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ParticipantEventsQuery, ParticipantEventsQueryVariables>) {
+          return Apollo.useLazyQuery<ParticipantEventsQuery, ParticipantEventsQueryVariables>(ParticipantEventsDocument, baseOptions);
         }
-export type GetParticipatingEventsQueryHookResult = ReturnType<typeof useGetParticipatingEventsQuery>;
-export type GetParticipatingEventsLazyQueryHookResult = ReturnType<typeof useGetParticipatingEventsLazyQuery>;
-export type GetParticipatingEventsQueryResult = Apollo.QueryResult<GetParticipatingEventsQuery, GetParticipatingEventsQueryVariables>;
+export type ParticipantEventsQueryHookResult = ReturnType<typeof useParticipantEventsQuery>;
+export type ParticipantEventsLazyQueryHookResult = ReturnType<typeof useParticipantEventsLazyQuery>;
+export type ParticipantEventsQueryResult = Apollo.QueryResult<ParticipantEventsQuery, ParticipantEventsQueryVariables>;

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -83,12 +83,12 @@ export type Mutation = {
 
 
 export type MutationCreateEventArgs = {
-  input: CreateEventInput;
+  event: CreateEventInput;
 };
 
 
 export type MutationCreateUserArgs = {
-  input: CreateUserInput;
+  user: CreateUserInput;
 };
 
 
@@ -120,12 +120,12 @@ export type MutationLoginArgs = {
 
 
 export type MutationUpdateEventArgs = {
-  input: UpdateEventInput;
+  event: UpdateEventInput;
 };
 
 
 export type MutationUpdateUserArgs = {
-  input: UpdateUserInput;
+  user: UpdateUserInput;
 };
 
 
@@ -213,7 +213,7 @@ export type User = {
 };
 
 export type CreateEventMutationVariables = Exact<{
-  input: CreateEventInput;
+  event: CreateEventInput;
 }>;
 
 
@@ -239,7 +239,7 @@ export type UploadFileMutation = (
 );
 
 export type CreateUserMutationVariables = Exact<{
-  input: CreateUserInput;
+  user: CreateUserInput;
 }>;
 
 
@@ -321,8 +321,8 @@ export type ParticipantEventsQuery = (
 
 
 export const CreateEventDocument = gql`
-    mutation CreateEvent($input: CreateEventInput!) {
-  createEvent(input: $input) {
+    mutation CreateEvent($event: CreateEventInput!) {
+  createEvent(event: $event) {
     id
   }
 }
@@ -342,7 +342,7 @@ export type CreateEventMutationFn = Apollo.MutationFunction<CreateEventMutation,
  * @example
  * const [createEventMutation, { data, loading, error }] = useCreateEventMutation({
  *   variables: {
- *      input: // value for 'input'
+ *      event: // value for 'event'
  *   },
  * });
  */
@@ -386,8 +386,8 @@ export type UploadFileMutationHookResult = ReturnType<typeof useUploadFileMutati
 export type UploadFileMutationResult = Apollo.MutationResult<UploadFileMutation>;
 export type UploadFileMutationOptions = Apollo.BaseMutationOptions<UploadFileMutation, UploadFileMutationVariables>;
 export const CreateUserDocument = gql`
-    mutation CreateUser($input: CreateUserInput!) {
-  createUser(input: $input) {
+    mutation CreateUser($user: CreateUserInput!) {
+  createUser(user: $user) {
     id
   }
 }
@@ -407,7 +407,7 @@ export type CreateUserMutationFn = Apollo.MutationFunction<CreateUserMutation, C
  * @example
  * const [createUserMutation, { data, loading, error }] = useCreateUserMutation({
  *   variables: {
- *      input: // value for 'input'
+ *      user: // value for 'user'
  *   },
  * });
  */

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -1,6 +1,6 @@
 # Creating Events
-mutation CreateEvent($createEventInput: CreateEventInput!) {
-  createEvent(createEventInput: $createEventInput) {
+mutation CreateEvent($input: CreateEventInput!) {
+  createEvent(input: $input) {
     id
   }
 }
@@ -14,8 +14,8 @@ mutation UploadFile($file: Upload!) {
 }
 
 # Register a user
-mutation CreateUser($createUserInput: CreateUserInput!) {
-  createUser(createUserInput: $createUserInput) {
+mutation CreateUser($input: CreateUserInput!) {
+  createUser(input: $input) {
     id
   }
 }

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -1,6 +1,6 @@
 # Creating Events
-mutation CreateEvent($input: CreateEventInput!) {
-  createEvent(input: $input) {
+mutation CreateEvent($event: CreateEventInput!) {
+  createEvent(event: $event) {
     id
   }
 }
@@ -14,8 +14,8 @@ mutation UploadFile($file: Upload!) {
 }
 
 # Register a user
-mutation CreateUser($input: CreateUserInput!) {
-  createUser(input: $input) {
+mutation CreateUser($user: CreateUserInput!) {
+  createUser(user: $user) {
     id
   }
 }

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -1,6 +1,6 @@
 # Find events by Id
-query FindSpecificEvent($eventId: Int!) {
-  event(id: $eventId) {
+query Event($id: Int!) {
+  event(id: $id) {
     id
     title
     description
@@ -10,8 +10,8 @@ query FindSpecificEvent($eventId: Int!) {
   }
 }
 
-query DiscoverEvents($discoverEventsUserId: Int!) {
-  discoverEvents(userId: $discoverEventsUserId) {
+query DiscoverEvents($userId: Int!) {
+  discoverEvents(userId: $userId) {
     id
     title
     description
@@ -21,15 +21,15 @@ query DiscoverEvents($discoverEventsUserId: Int!) {
 }
 
 # Gets all related events to a user
-query GetUsersEvents($UserId: Int!) {
-  coHostEvents(userId: $UserId) {
+query OwnedEvents($userId: Int!) {
+  coHostEvents(coHostId: $userId) {
     id
     title
     description
     startDate
     endDate
   }
-  hostEvents(userId: $UserId) {
+  hostEvents(hostId: $userId) {
     id
     title
     description
@@ -39,8 +39,8 @@ query GetUsersEvents($UserId: Int!) {
 }
 
 # Get all the events that a user is participating in
-query GetParticipatingEvents($participatingEventsUserId: Int!) {
-  participatingEvents(userId: $participatingEventsUserId) {
+query ParticipantEvents($userId: Int!) {
+  participantEvents(userId: $userId) {
     id
     endDate
     description


### PR DESCRIPTION
closes #146 

NOTE: This is a relatively small PR, most of the line changes are due to renames and from generated files. No changes in the app behaviour or bugs should occur. If you can run the tests and app without issues then everything should be good.

This PR aims to standardize the naming of the methods and queries in the backend.

Here's a summary of what was done (see commit messages for details):
* some resolver method names were simplified to make queries easier to write
* Some service method names were made longer so that its behaviour is easier to understand
* Queries in the front-end were adjusted to follow these new names
* some heavy logic found in some resolver methods was moved to the corresponding service methods. The tests were adjusted accordingly. as a reminder, the service should contain the business logic of a query, while the resolver should remain relatively light.
* `createEventInput`, `updateEventInput`, `createUserInput`, etc... variables names were renamed to be simply `user` or `event`. I did this to reduce redundancy since, for example, when you're writing a createEvent query you should know that your input is for the create event query, there's no need to reiterate. Also, the input object you're passing is technically an event, or at least partially one.