### PR TITLE
TASK-30: Frontend OAuth Login Logic

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -14,6 +14,7 @@ import MyEventsPage from './pages/home/my-events/my-events';
 import UpcomingPage from './pages/home/upcoming/upcoming';
 import LoginPage from './pages/login/login';
 import RegisterPage from './pages/register/register';
+import TokenRedirectPage from './pages/token-redirect/token-redirect';
 
 /**
  * Main component of the application
@@ -50,6 +51,7 @@ export const App = () => {
         <Switch>
           <Route exact path={ROUTES.LOGIN} component={LoginPage} />
           <Route exact path={ROUTES.REGISTER} component={RegisterPage} />
+          <Route exact path={ROUTES.TOKEN_REDIRECT} component={TokenRedirectPage} />
 
           {/* If accessToken isn't set, redirect user to login page. Disabled for now as it will break e2e tests, will be implemented properly in US-7.6 */}
           {/* {!accessToken ? <Redirect to={ROUTES.LOGIN} /> : null} */}

--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation } from '@apollo/client';
 import { faFacebookSquare, faGoogle, faTwitter } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { ILoginForm } from '@mull/types';
+import { IAuthToken, ILoginForm } from '@mull/types';
 import { useFormik } from 'formik';
 import { History } from 'history';
 import jwtDecode from 'jwt-decode';
@@ -68,7 +68,7 @@ export const Login = ({ history }: LoginProps) => {
       setAccessToken(accessToken);
 
       try {
-        var decodedToken = jwtDecode(accessToken) as { id: number };
+        var decodedToken: IAuthToken = jwtDecode(accessToken);
       } catch (err) {
         console.error(err);
         updateToast(toast.TYPE.ERROR, `Received an invalid token`);

--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -1,4 +1,3 @@
-import { gql, useMutation } from '@apollo/client';
 import { faFacebookSquare, faGoogle, faTwitter } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IAuthToken, ILoginForm } from '@mull/types';
@@ -12,25 +11,18 @@ import * as Yup from 'yup';
 import logo from '../../../assets/mull-logo.png';
 import { ROUTES } from '../../../constants';
 import { environment } from '../../../environments/environment';
+import { useLoginMutation } from '../../../generated/graphql';
 import { CustomTextInput } from '../../components';
 import UserContext from '../../context/user.context';
 import { useToast } from '../../hooks/useToast';
 import './login.scss';
-
-export const LOGIN = gql`
-  mutation Login($loginInput: LoginInput!) {
-    login(loginInput: $loginInput) {
-      accessToken
-    }
-  }
-`;
 
 export interface LoginProps {
   history: History;
 }
 
 export const Login = ({ history }: LoginProps) => {
-  const [login] = useMutation(LOGIN);
+  const [login] = useLoginMutation();
   const { setUserId, setAccessToken } = useContext(UserContext);
   const { notifyToast, updateToast } = useToast();
 

--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -63,7 +63,7 @@ export const Login = ({ history }: LoginProps) => {
         var decodedToken: IAuthToken = jwtDecode(accessToken);
       } catch (err) {
         console.error(err);
-        updateToast(toast.TYPE.ERROR, `Received an invalid token`);
+        updateToast(toast.TYPE.ERROR, `Invalid Login Token`);
         return;
       }
 

--- a/apps/mull-ui/src/app/pages/token-redirect/token-redirect.spec.tsx
+++ b/apps/mull-ui/src/app/pages/token-redirect/token-redirect.spec.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { createMemoryHistory, History } from 'history';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { UserProvider } from '../../context/user.context';
+import TokenRedirectPage from './token-redirect';
+
+const mockUserProvider = () => ({
+  setUserId: jest.fn(),
+  userId: null,
+  accessToken: null,
+  setAccessToken: jest.fn(),
+});
+
+describe('TokenRedirectPage', () => {
+  const renderHelper = (history: History, token: string, userProvider) => {
+    return (
+      <UserProvider value={userProvider}>
+        <MemoryRouter initialEntries={[`token-redirect/${token}`]}>
+          <Route path="token-redirect/:token">
+            <TokenRedirectPage history={history} />
+          </Route>
+        </MemoryRouter>
+      </UserProvider>
+    );
+  };
+  it('should render successfully', () => {
+    const mockProvider = mockUserProvider();
+    const history = createMemoryHistory();
+    const { baseElement } = render(renderHelper(history, 'abc123', mockProvider));
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should invalidate an access token', async () => {
+    const mockProvider = mockUserProvider();
+    const history = createMemoryHistory();
+    render(renderHelper(history, '123', mockProvider));
+    expect(mockProvider.setAccessToken).not.toBeCalled();
+    expect(mockProvider.setUserId).not.toBeCalled();
+  });
+
+  it('should validate an access token', async () => {
+    const mockProvider = mockUserProvider();
+    const history = createMemoryHistory();
+    render(
+      renderHelper(
+        history,
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTEsImlhdCI6MTYxMDc1MzYzNiwiZXhwIjoxNjEwNzU0NTM2fQ.AjBTwCmOpPhbse8BGdQzerzEl9LfTDVs5BZZMTfyALw',
+        mockProvider
+      )
+    );
+    expect(mockProvider.setAccessToken).toBeCalled();
+    expect(mockProvider.setUserId).toBeCalled();
+  });
+});

--- a/apps/mull-ui/src/app/pages/token-redirect/token-redirect.tsx
+++ b/apps/mull-ui/src/app/pages/token-redirect/token-redirect.tsx
@@ -1,0 +1,38 @@
+import { IAuthToken } from '@mull/types';
+import { History } from 'history';
+import jwtDecode from 'jwt-decode';
+import React, { useContext, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { ROUTES } from '../../../constants';
+import UserContext from '../../context/user.context';
+
+export interface TokenRedirectPageProps {
+  history: History;
+}
+
+const TokenRedirectPage = ({ history }: TokenRedirectPageProps) => {
+  const { setAccessToken, setUserId } = useContext(UserContext);
+  const { token } = useParams<{ token: string }>();
+
+  useEffect(() => {
+    try {
+      const decodedToken: IAuthToken = jwtDecode(token);
+      setAccessToken(token);
+      setUserId(decodedToken.id);
+      toast('Successfully Logged In', { type: toast.TYPE.SUCCESS });
+      history.push(ROUTES.HOME);
+    } catch (err) {
+      toast('Invalid Login Token', { type: toast.TYPE.ERROR });
+      history.push(ROUTES.LOGIN);
+    }
+  });
+
+  return (
+    <div className="page-container">
+      <p>Redirecting to home...</p>
+    </div>
+  );
+};
+
+export default TokenRedirectPage;

--- a/apps/mull-ui/src/constants.ts
+++ b/apps/mull-ui/src/constants.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   LOGIN: '/login',
   REGISTER: '/register',
   EVENT_BY_ID: '/events/:id',
+  TOKEN_REDIRECT: '/token-redirect/:token',
 };
 
 export const DAY_IN_MILLISECONDS = 86400000;

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -251,6 +251,19 @@ export type CreateUserMutation = (
   ) }
 );
 
+export type LoginMutationVariables = Exact<{
+  loginInput: LoginInput;
+}>;
+
+
+export type LoginMutation = (
+  { __typename?: 'Mutation' }
+  & { login: (
+    { __typename?: 'LoginResult' }
+    & Pick<LoginResult, 'accessToken'>
+  ) }
+);
+
 export type FindSpecificEventQueryVariables = Exact<{
   eventId: Scalars['Int'];
 }>;
@@ -404,6 +417,38 @@ export function useCreateUserMutation(baseOptions?: Apollo.MutationHookOptions<C
 export type CreateUserMutationHookResult = ReturnType<typeof useCreateUserMutation>;
 export type CreateUserMutationResult = Apollo.MutationResult<CreateUserMutation>;
 export type CreateUserMutationOptions = Apollo.BaseMutationOptions<CreateUserMutation, CreateUserMutationVariables>;
+export const LoginDocument = gql`
+    mutation Login($loginInput: LoginInput!) {
+  login(loginInput: $loginInput) {
+    accessToken
+  }
+}
+    `;
+export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutationVariables>;
+
+/**
+ * __useLoginMutation__
+ *
+ * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLoginMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [loginMutation, { data, loading, error }] = useLoginMutation({
+ *   variables: {
+ *      loginInput: // value for 'loginInput'
+ *   },
+ * });
+ */
+export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
+        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
+      }
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
+export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
+export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const FindSpecificEventDocument = gql`
     query FindSpecificEvent($eventId: Int!) {
   event(id: $eventId) {

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -19,3 +19,10 @@ mutation CreateUser($createUserInput: CreateUserInput!) {
     id
   }
 }
+
+# Login a user
+mutation Login($loginInput: LoginInput!) {
+  login(loginInput: $loginInput) {
+    accessToken
+  }
+}

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -61,6 +61,12 @@ export interface IMedia {
   mediaType: string;
 }
 
+export interface IAuthToken {
+  id: number;
+  iat: number;
+  exp: number;
+}
+
 export type GqlContext = {
   req: Request;
   res: Response;


### PR DESCRIPTION
This PR closes #112.

**Steps to Test**
1. Launch the application using `nx serve mull-ui` & `nx serve mull-api`.
2. Navigate to the login page.
3. Click one of the OAuth buttons and proceed to login.
4. You should get a success message and be redirected to the discover page.
5. Navigate to `localhost:4200/token-redirect/<INVALID_TOKEN>`
   - where INVALID_TOKEN can be any string
6. You should get an error and be redirected to the login page.