### PR TITLE
US-2.8: Joining events

### DIFF
--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -37,11 +37,11 @@ export class EventResolver {
   }
 
   @Query(/* istanbul ignore next */ () => Boolean)
-  async participatingEvent(
+  async isParticipant(
     @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
     @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
   ) {
-    return this.eventService.findJoinedEvent(eventId, userId);
+    return this.eventService.isUserAttendingEvent(eventId, userId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -41,7 +41,7 @@ export class EventResolver {
     @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
     @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
   ) {
-    return !!(await this.eventService.findJoinedEvent(eventId, userId));
+    return this.eventService.findJoinedEvent(eventId, userId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -36,6 +36,14 @@ export class EventResolver {
     return this.eventService.getEventsAttendedByUser(userId);
   }
 
+  @Query(/* istanbul ignore next */ () => Boolean)
+  async participatingEvent(
+    @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
+    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+  ) {
+    return !!(await this.eventService.findJoinedEvent(eventId, userId));
+  }
+
   @Query(/* istanbul ignore next */ () => [Event])
   async discoverEvents(
     @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
@@ -59,13 +67,19 @@ export class EventResolver {
   }
 
   @Mutation(() => Boolean)
-  async joinEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+  async joinEvent(
+    @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
+    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+  ) {
     this.eventService.addEventParticipant(eventId, userId);
     return true;
   }
 
   @Mutation(() => Boolean)
-  async leaveEvent(@Args('eventId') eventId: number, @Args('userId') userId: number) {
+  async leaveEvent(
+    @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
+    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+  ) {
     this.eventService.removeEventParticipant(eventId, userId);
     return true;
   }

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -156,6 +156,20 @@ describe('EventService', () => {
     expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
   });
 
+  it('should return an event that a user has joined', async () => {
+    const participantId = mockAllUsers[2].id;
+    const eventId = mockAllEvents[0].id;
+    repository.createQueryBuilder.mockImplementation(() => ({
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockReturnValue(mockAllEvents[0]),
+    }));
+    const foundEvent = await service.findJoinedEvent(eventId, participantId);
+    expect(foundEvent).toEqual(mockAllEvents[0]);
+    expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
+  });
+
   it('should return all the events a user is not involved in', async () => {
     const userId = mockAllUsers[2].id;
     repository.createQueryBuilder.mockImplementation(() => ({

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -156,7 +156,7 @@ describe('EventService', () => {
     expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
   });
 
-  it('should return an event that a user has joined', async () => {
+  it('should check if a user joined an event', async () => {
     const participantId = mockAllUsers[2].id;
     const eventId = mockAllEvents[0].id;
     repository.createQueryBuilder.mockImplementation(() => ({
@@ -165,8 +165,8 @@ describe('EventService', () => {
       andWhere: jest.fn().mockReturnThis(),
       getOne: jest.fn().mockReturnValue(mockAllEvents[0]),
     }));
-    const foundEvent = await service.findJoinedEvent(eventId, participantId);
-    expect(foundEvent).toEqual(mockAllEvents[0]);
+    const foundEvent = await service.isUserAttendingEvent(eventId, participantId);
+    expect(foundEvent).toEqual(true);
     expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -11,7 +11,7 @@ export type MockType<T> = {
   [P in keyof T]: jest.Mock<{}>;
 };
 
-const mockEventRepositoy = () => ({
+const mockEventRepository = () => ({
   create: jest.fn((mockUserData: CreateEventInput) => ({ ...mockUserData })),
   findOne: jest.fn((id: number) => {
     return mockAllEvents.find((event) => event.id === id);
@@ -39,7 +39,7 @@ describe('EventService', () => {
         EventService,
         {
           provide: getRepositoryToken(Event),
-          useFactory: mockEventRepositoy,
+          useFactory: mockEventRepository,
         },
       ],
     }).compile();

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -26,6 +26,7 @@ const mockEventRepositoy = () => ({
     andWhere: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockReturnValue(mockAllEvents[0]),
   })),
+  query: jest.fn().mockReturnThis(),
 });
 
 describe('EventService', () => {
@@ -164,7 +165,8 @@ describe('EventService', () => {
       getMany: jest.fn().mockReturnValue(mockAllEvents[2]),
     }));
     const foundEvents = await service.getEventsRecommendedToUser(userId);
+    repository.query.mockImplementation(() => mockAllEvents[2]);
     expect(foundEvents).toEqual(mockAllEvents[2]);
-    expect(repository.createQueryBuilder).toBeCalledTimes(1);
+    expect(repository.query).toBeCalledTimes(1);
   });
 });

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -178,8 +178,8 @@ describe('EventService', () => {
       andWhere: jest.fn().mockReturnThis(),
       getMany: jest.fn().mockReturnValue(mockAllEvents[2]),
     }));
-    const foundEvents = await service.getEventsRecommendedToUser(userId);
     repository.query.mockImplementation(() => mockAllEvents[2]);
+    const foundEvents = await service.getEventsRecommendedToUser(userId);
     expect(foundEvents).toEqual(mockAllEvents[2]);
     expect(repository.query).toBeCalledTimes(1);
   });

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -74,10 +74,10 @@ export class EventService {
   async getEventsRecommendedToUser(userId: number): Promise<Event[]> {
     const discoverableEvents = await this.eventRepository.query(
       `
-    SELECT DISTINCT id, title, startDate, endDate, description, imageId, hostId, locationId, restriction FROM mull.event LEFT JOIN mull.event_participants ON mull.event.id = mull.event_participants.eventId
-    WHERE id NOT IN (SELECT mull.event.id FROM mull.event WHERE mull.event.hostId = ${userId}) AND 
-    id NOT IN (SELECT mull.event_participants.eventId FROM mull.event_participants WHERE mull.event_participants.userId = ${userId}) AND 
-    id NOT IN (SELECT mull.event_cohosts.eventId FROM mull.event_cohosts WHERE mull.event_cohosts.userId = ${userId})`
+    SELECT DISTINCT id, title, startDate, endDate, description, imageId, hostId, locationId, restriction FROM event LEFT JOIN event_participants ON event.id = event_participants.eventId
+    WHERE id NOT IN (SELECT event.id FROM event WHERE event.hostId = ${userId}) AND 
+    id NOT IN (SELECT event_participants.eventId FROM event_participants WHERE event_participants.userId = ${userId}) AND 
+    id NOT IN (SELECT event_cohosts.eventId FROM event_cohosts WHERE event_cohosts.userId = ${userId})`
     );
     return discoverableEvents;
   }

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -46,7 +46,7 @@ export class EventService {
       .getMany();
   }
 
-  async isUserAttendingEvent(eventId: number, userId: number): Promise<Boolean> {
+  async isUserAttendingEvent(eventId: number, userId: number): Promise<boolean> {
     const event = await this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.participants', 'user')

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -51,12 +51,9 @@ export class EventService {
       .createQueryBuilder('event')
       .leftJoin('event.participants', 'user')
       .leftJoin('event.coHosts', 'coHost')
-      .leftJoin('event.host', 'host')
       .where(
         new Brackets((qb) => {
-          qb.where('coHost.id = :userId', { userId })
-            .orWhere('user.id = :userId', { userId })
-            .orWhere('host.id = :userId', { userId });
+          qb.where('coHost.id = :userId', { userId }).orWhere('user.id = :userId', { userId });
         })
       )
       .andWhere(

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -46,8 +46,8 @@ export class EventService {
       .getMany();
   }
 
-  findJoinedEvent(eventId: number, userId: number): Promise<Event> {
-    return this.eventRepository
+  async findJoinedEvent(eventId: number, userId: number): Promise<Boolean> {
+    const participantEventCheck = await this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.participants', 'user')
       .leftJoin('event.coHosts', 'coHost')
@@ -62,6 +62,11 @@ export class EventService {
         })
       )
       .getOne();
+    if (participantEventCheck) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -46,8 +46,8 @@ export class EventService {
       .getMany();
   }
 
-  async findJoinedEvent(eventId: number, userId: number): Promise<Boolean> {
-    const participantEventCheck = await this.eventRepository
+  async isUserAttendingEvent(eventId: number, userId: number): Promise<Boolean> {
+    const event = await this.eventRepository
       .createQueryBuilder('event')
       .leftJoin('event.participants', 'user')
       .leftJoin('event.coHosts', 'coHost')
@@ -62,7 +62,7 @@ export class EventService {
         })
       )
       .getOne();
-    if (participantEventCheck) {
+    if (event) {
       return true;
     } else {
       return false;

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -72,8 +72,10 @@ type Query {
   event(id: Int!): Event!
   events: [Event!]!
   getAutocompletedLocations(userInput: String!): [String!]!
-  hostEvents(hostId: Int!): [Event!]!
   participantEvents(userId: Int!): [Event!]!
+  hostEvents(userId: Int!): [Event!]!
+  isParticipant(eventId: Int!, userId: Int!): Boolean!
+  participatingEvents(userId: Int!): [Event!]!
   user(id: Int!): User!
   users: [User!]!
 }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -58,8 +58,8 @@ type Mutation {
   createUser(user: CreateUserInput!): User!
   deleteEvent(id: Int!): Event!
   deleteUser(id: Int!): User!
-  joinEvent(eventId: Float!, userId: Float!): Boolean!
-  leaveEvent(eventId: Float!, userId: Float!): Boolean!
+  joinEvent(eventId: Int!, userId: Int!): Boolean!
+  leaveEvent(eventId: Int!, userId: Int!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
   updateEvent(event: UpdateEventInput!): Event!
   updateUser(user: UpdateUserInput!): User!
@@ -72,10 +72,9 @@ type Query {
   event(id: Int!): Event!
   events: [Event!]!
   getAutocompletedLocations(userInput: String!): [String!]!
-  participantEvents(userId: Int!): [Event!]!
-  hostEvents(userId: Int!): [Event!]!
+  hostEvents(hostId: Int!): [Event!]!
   isParticipant(eventId: Int!, userId: Int!): Boolean!
-  participatingEvents(userId: Int!): [Event!]!
+  participantEvents(userId: Int!): [Event!]!
   user(id: Int!): User!
   users: [User!]!
 }

--- a/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
@@ -1,0 +1,21 @@
+/// <reference types="Cypress" />
+import { frameSizes } from './../fixtures/frame-sizes';
+
+frameSizes.forEach((frame) => {
+  describe(`US-2.8: Joining Events (${frame.name} view)`, () => {
+    beforeEach(() => {
+      cy.viewport(frame.res[0], frame.res[1]);
+    });
+
+    it('should join an event on the discover event page', () => {
+      cy.visit('http://localhost:4200/home/discover');
+      cy.get('#event-card-join').click();
+    });
+
+    it('should join an event on the preview event page', () => {
+      cy.visit('http://localhost:4200/home/discover');
+      cy.get(':nth-child(1) > .event-card-image').click();
+      cy.get('[data-testid=mull-button]').click();
+    });
+  });
+});

--- a/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
@@ -17,5 +17,16 @@ frameSizes.forEach((frame) => {
       cy.get(':nth-child(1) > .event-card-image').click();
       cy.get('[data-testid=mull-button]').click();
     });
+
+    it('should leave an event on the upcoming event page', () => {
+      cy.visit('http://localhost:4200/home/upcoming');
+      cy.get('#event-card-join').click();
+    });
+
+    it('should leave an event on the preview event page', () => {
+      cy.visit('http://localhost:4200/home/upcoming');
+      cy.get('.discover-page-tabs-container > :nth-child(1) > .event-card-image').click();
+      cy.get('[data-testid=mull-button]').click();
+    });
   });
 });

--- a/apps/mull-ui/src/app/components/event-card/__snapshots__/event-card.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/event-card/__snapshots__/event-card.spec.tsx.snap
@@ -25,6 +25,7 @@ exports[`EventCard should match snapshot 1`] = `
   </div>
   <button
     className="event-card-join "
+    id="event-card-join"
     onClick={[Function]}
   >
     <svg

--- a/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
@@ -8,39 +8,31 @@ import { dummyEvent } from '../../../constants';
 import EventCard from './event-card';
 
 describe('EventCard', () => {
-  const history = createMemoryHistory();
-  it('should render successfully', () => {
-    const { baseElement } = render(
+  const renderHelper = (history: History) => {
+    return (
       <MockedProvider>
         <Router history={history}>
           <EventCard event={dummyEvent} />
         </Router>
       </MockedProvider>
     );
+  };
+
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+    const { baseElement } = render(renderHelper(history));
     expect(baseElement).toBeTruthy();
   });
 
   it('should match snapshot', () => {
-    const tree = renderer
-      .create(
-        <MockedProvider>
-          <Router history={history}>
-            <EventCard event={dummyEvent} />
-          </Router>
-        </MockedProvider>
-      )
-      .toJSON();
+    const history = createMemoryHistory();
+    const tree = renderer.create(renderHelper(history)).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('should render dates correctly', () => {
-    const dom = render(
-      <MockedProvider>
-        <Router history={history}>
-          <EventCard event={dummyEvent} />
-        </Router>
-      </MockedProvider>
-    );
+    const history = createMemoryHistory();
+    const dom = render(renderHelper(history));
 
     const dateDiv = dom.getByTestId('event-card-datetime');
     expect(dateDiv.textContent).toBe('15 JUN01:45PM');

--- a/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.spec.tsx
@@ -1,22 +1,46 @@
+import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
+import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 import { dummyEvent } from '../../../constants';
 import EventCard from './event-card';
 
 describe('EventCard', () => {
+  const history = createMemoryHistory();
   it('should render successfully', () => {
-    const { baseElement } = render(<EventCard event={dummyEvent} />);
+    const { baseElement } = render(
+      <MockedProvider>
+        <Router history={history}>
+          <EventCard event={dummyEvent} />
+        </Router>
+      </MockedProvider>
+    );
     expect(baseElement).toBeTruthy();
   });
 
   it('should match snapshot', () => {
-    const tree = renderer.create(<EventCard event={dummyEvent} />).toJSON();
+    const tree = renderer
+      .create(
+        <MockedProvider>
+          <Router history={history}>
+            <EventCard event={dummyEvent} />
+          </Router>
+        </MockedProvider>
+      )
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('should render dates correctly', () => {
-    const dom = render(<EventCard event={dummyEvent} />);
+    const dom = render(
+      <MockedProvider>
+        <Router history={history}>
+          <EventCard event={dummyEvent} />
+        </Router>
+      </MockedProvider>
+    );
 
     const dateDiv = dom.getByTestId('event-card-datetime');
     expect(dateDiv.textContent).toBe('15 JUN01:45PM');

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
 import React, { useState } from 'react';
 import { dummyProfilePictures } from '../../../constants'; // TODO query the participants profile pictures
+import { useJoinEventMutation, useRemoveJoinedEventMutation } from '../../../generated/graphql';
 import { formatDate } from '../../../utilities';
 import EventMembers from '../event-members/event-members';
 import './event-card.scss';
@@ -10,13 +11,21 @@ import './event-card.scss';
 export interface EventCardProps {
   event: Partial<ISerializedEvent>;
   style?: React.CSSProperties;
+  isJoined?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
-export const EventCard = ({ event, style = {}, onClick }: EventCardProps) => {
-  // TODO; set joined based on if current user is part of event
-  const [joined, setJoined] = useState<boolean>(false);
+export const EventCard = ({ event, style = {}, onClick, isJoined = false }: EventCardProps) => {
   const { day, month, time } = formatDate(new Date(event.startDate));
+
+  const [joined, setJoined] = useState<boolean>(isJoined);
+  const eventId = Number(event.id);
+  // TODO: Have a user object when logged in to access userId
+  const userId = 1;
+
+  const [joinEvent] = useJoinEventMutation();
+  const [removeJoinedEvent] = useRemoveJoinedEventMutation();
+
   return (
     <div className="event-card-container button" onClick={onClick} style={style}>
       <img
@@ -34,8 +43,14 @@ export const EventCard = ({ event, style = {}, onClick }: EventCardProps) => {
         onClick={(e) => {
           e.stopPropagation();
           setJoined(!joined);
+          if (joined == false) {
+            joinEvent({ variables: { eventId, userId } });
+          } else {
+            removeJoinedEvent({ variables: { eventId, userId } });
+          }
         }}
         className={`event-card-join ${joined ? 'joined' : ''}`}
+        id={'event-card-join'}
       >
         <FontAwesomeIcon icon={joined ? faCheck : faSignInAlt} />
       </button>

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -19,7 +19,7 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
   const { day, month, time } = formatDate(new Date(event.startDate));
 
   const [joined, setJoined] = useState<boolean>(isJoined);
-  const eventId = Number(event.id);
+  const eventId = parseInt(event.id);
   // TODO: Have a user object when logged in to access userId
   const userId = 1;
 

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -24,7 +24,7 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
   const userId = 1;
 
   const [joinEvent] = useJoinEventMutation();
-  const [removeJoinedEvent] = useLeaveEventMutation();
+  const [leaveEvent] = useLeaveEventMutation();
 
   return (
     <div className="event-card-container button" onClick={onClick} style={style}>
@@ -46,7 +46,7 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
           if (joined == false) {
             joinEvent({ variables: { eventId, userId } });
           } else {
-            removeJoinedEvent({ variables: { eventId, userId } });
+            leaveEvent({ variables: { eventId, userId } });
           }
         }}
         className={`event-card-join ${joined ? 'joined' : ''}`}

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
 import React, { useState } from 'react';
 import { dummyProfilePictures } from '../../../constants'; // TODO query the participants profile pictures
-import { useJoinEventMutation, useRemoveJoinedEventMutation } from '../../../generated/graphql';
+import { useJoinEventMutation, useLeaveEventMutation } from '../../../generated/graphql';
 import { formatDate } from '../../../utilities';
 import EventMembers from '../event-members/event-members';
 import './event-card.scss';
@@ -24,7 +24,7 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
   const userId = 1;
 
   const [joinEvent] = useJoinEventMutation();
-  const [removeJoinedEvent] = useRemoveJoinedEventMutation();
+  const [removeJoinedEvent] = useLeaveEventMutation();
 
   return (
     <div className="event-card-container button" onClick={onClick} style={style}>

--- a/apps/mull-ui/src/app/components/event-page-info/__snapshots__/event-page-info.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/event-page-info/__snapshots__/event-page-info.spec.tsx.snap
@@ -186,12 +186,12 @@ exports[`EventPageInfo should match snapshot 1`] = `
     </svg>
   </div>
   <button
-    className="mull-button event-page-button"
+    className="mull-button event-page-button event-page-joined-button"
     data-testid="mull-button"
     onClick={[Function]}
     type="submit"
   >
-    Join
+    Leave
   </button>
 </div>
 `;

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.scss
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.scss
@@ -17,7 +17,7 @@
 }
 
 .event-page-joined-button {
-  border: 1.5px solid #27b09a;
+  border: 1.5px solid $primary-color;
   background: white;
   color: black;
 }

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.scss
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.scss
@@ -16,6 +16,12 @@
   margin: 0.9rem 0;
 }
 
+.event-page-joined-button {
+  border: 1.5px solid #27b09a;
+  background: white;
+  color: black;
+}
+
 .row-text {
   flex: 1;
   padding: 0 1rem;

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
@@ -8,28 +8,25 @@ import { dummyEvent } from '../../../constants';
 import EventPageInfo from './event-page-info';
 
 describe('EventPageInfo', () => {
-  const history = createMemoryHistory();
-  it('should render successfully', () => {
-    const { baseElement } = render(
+  const renderHelper = (history: History) => {
+    return (
       <MockedProvider>
         <Router history={history}>
           <EventPageInfo isJoined={true} isReview={false} event={dummyEvent} />
         </Router>
       </MockedProvider>
     );
+  };
+
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+    const { baseElement } = render(renderHelper(history));
     expect(baseElement).toBeTruthy();
   });
 
   it('should match snapshot', () => {
-    const tree = renderer
-      .create(
-        <MockedProvider>
-          <Router history={history}>
-            <EventPageInfo isJoined={true} isReview={false} event={dummyEvent} />
-          </Router>
-        </MockedProvider>
-      )
-      .toJSON();
+    const history = createMemoryHistory();
+    const tree = renderer.create(renderHelper(history)).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.spec.tsx
@@ -1,17 +1,35 @@
+import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
+import { Router } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 import { dummyEvent } from '../../../constants';
 import EventPageInfo from './event-page-info';
 
 describe('EventPageInfo', () => {
+  const history = createMemoryHistory();
   it('should render successfully', () => {
-    const { baseElement } = render(<EventPageInfo event={dummyEvent} />);
+    const { baseElement } = render(
+      <MockedProvider>
+        <Router history={history}>
+          <EventPageInfo isJoined={true} isReview={false} event={dummyEvent} />
+        </Router>
+      </MockedProvider>
+    );
     expect(baseElement).toBeTruthy();
   });
 
   it('should match snapshot', () => {
-    const tree = renderer.create(<EventPageInfo event={dummyEvent} />).toJSON();
+    const tree = renderer
+      .create(
+        <MockedProvider>
+          <Router history={history}>
+            <EventPageInfo isJoined={true} isReview={false} event={dummyEvent} />
+          </Router>
+        </MockedProvider>
+      )
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -35,7 +35,7 @@ export const EventPageInfo = ({
   buttonType,
 }: EventPageInfoProps) => {
   const [joinEvent] = useJoinEventMutation();
-  const [removeJoinedEvent] = useLeaveEventMutation();
+  const [leaveEvent] = useLeaveEventMutation();
 
   const eventId = Number(event.id);
   // TODO: Have a user object when logged in to access userId
@@ -88,31 +88,21 @@ export const EventPageInfo = ({
         <p className="row-text">{event.participants?.map((p) => p.name).join(', ')}</p>
         <FontAwesomeIcon icon={faUserPlus} className="event-page-icon color-green" />
       </div>
-      {joined ? (
-        <MullButton
-          className="event-page-button event-page-joined-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setJoined(!joined);
-            removeJoinedEvent({ variables: { eventId, userId } });
-          }}
-          type={buttonType}
-        >
-          {'Leave'}
-        </MullButton>
-      ) : (
-        <MullButton
-          className="event-page-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setJoined(!joined);
+      <MullButton
+        className={`event-page-button ${joined ? 'event-page-joined-button' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setJoined(!joined);
+          if (joined) {
+            leaveEvent({ variables: { eventId, userId } });
+          } else {
             joinEvent({ variables: { eventId, userId } });
-          }}
-          type={buttonType}
-        >
-          {isReview ? 'Create' : 'Join'}
-        </MullButton>
-      )}
+          }
+        }}
+        type={buttonType}
+      >
+        {joined ? 'Leave' : isReview ? 'Create' : 'Join'}
+      </MullButton>
     </div>
   );
 };

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -37,7 +37,7 @@ export const EventPageInfo = ({
   const [joinEvent] = useJoinEventMutation();
   const [leaveEvent] = useLeaveEventMutation();
 
-  const eventId = Number(event.id);
+  const eventId = parseInt(event.id);
   // TODO: Have a user object when logged in to access userId
   const userId = 1;
 

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -9,7 +9,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { EventRestrictionMap, ISerializedEvent } from '@mull/types';
-import React from 'react';
+import React, { useState } from 'react';
+import { useJoinEventMutation, useRemoveJoinedEventMutation } from '../../../generated/graphql';
 import MullButton from '../mull-button/mull-button';
 import { ExpandableText } from './../expandable-text/expandable-text';
 import './event-page-info.scss';
@@ -18,6 +19,7 @@ export interface EventPageInfoProps {
   event: Partial<ISerializedEvent>;
   className?: string;
   isReview: boolean;
+  isJoined: boolean;
   buttonType?: 'submit' | 'button' | 'reset';
   handleMullButton?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
@@ -28,10 +30,19 @@ export interface EventPageInfoProps {
 export const EventPageInfo = ({
   event,
   className = '',
-  handleMullButton,
   isReview,
+  isJoined,
   buttonType,
 }: EventPageInfoProps) => {
+  const [joinEvent] = useJoinEventMutation();
+  const [removeJoinedEvent] = useRemoveJoinedEventMutation();
+
+  const eventId = Number(event.id);
+  // TODO: Have a user object when logged in to access userId
+  const userId = 1;
+
+  const [joined, setJoined] = useState<boolean>(isJoined);
+
   return (
     <div className={`event-page-info-container ${className}`}>
       <div className="info-row">
@@ -77,9 +88,31 @@ export const EventPageInfo = ({
         <p className="row-text">{event.participants?.map((p) => p.name).join(', ')}</p>
         <FontAwesomeIcon icon={faUserPlus} className="event-page-icon color-green" />
       </div>
-      <MullButton className="event-page-button" onClick={handleMullButton} type={buttonType}>
-        {isReview ? 'Create' : 'Join'}
-      </MullButton>
+      {joined ? (
+        <MullButton
+          className="event-page-button event-page-joined-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setJoined(!joined);
+            removeJoinedEvent({ variables: { eventId, userId } });
+          }}
+          type={buttonType}
+        >
+          {'Leave'}
+        </MullButton>
+      ) : (
+        <MullButton
+          className="event-page-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setJoined(!joined);
+            joinEvent({ variables: { eventId, userId } });
+          }}
+          type={buttonType}
+        >
+          {isReview ? 'Create' : 'Join'}
+        </MullButton>
+      )}
     </div>
   );
 };

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -10,7 +10,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { EventRestrictionMap, ISerializedEvent } from '@mull/types';
 import React, { useState } from 'react';
-import { useJoinEventMutation, useRemoveJoinedEventMutation } from '../../../generated/graphql';
+import { useJoinEventMutation, useLeaveEventMutation } from '../../../generated/graphql';
 import MullButton from '../mull-button/mull-button';
 import { ExpandableText } from './../expandable-text/expandable-text';
 import './event-page-info.scss';
@@ -35,7 +35,7 @@ export const EventPageInfo = ({
   buttonType,
 }: EventPageInfoProps) => {
   const [joinEvent] = useJoinEventMutation();
-  const [removeJoinedEvent] = useRemoveJoinedEventMutation();
+  const [removeJoinedEvent] = useLeaveEventMutation();
 
   const eventId = Number(event.id);
   // TODO: Have a user object when logged in to access userId

--- a/apps/mull-ui/src/app/pages/event-page/__snapshots__/event-page.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/event-page/__snapshots__/event-page.spec.tsx.snap
@@ -294,7 +294,7 @@ exports[`EventPage should match snapshot 1`] = `
         </svg>
       </div>
       <button
-        className="mull-button event-page-button"
+        className="mull-button event-page-button "
         data-testid="mull-button"
         onClick={[Function]}
         type="submit"

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -30,13 +30,13 @@ export const EventPage = ({
 
   const { loading, error, data } = useEventQuery({
     // TODO: dynamically pass current UserId
-    variables: { eventId, participatingEventUserId: 1 },
+    variables: { eventId, userId: 1 },
     skip: !!event,
   });
 
   if (!loading && data) {
     event = data.event;
-    isJoined = data.participatingEvent;
+    isJoined = data.isParticipant;
   }
 
   if (error) {

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { CreateEventInput, useEventQuery } from '../../../generated/graphql';
+import { CreateEventInput, useEventPageQuery } from '../../../generated/graphql';
 import { EventPageHeader, EventPageInfo } from '../../components';
 import './event-page.scss';
 
@@ -28,7 +28,7 @@ export const EventPage = ({
   const { id } = useParams<{ id: string }>();
   const eventId = parseInt(id);
 
-  const { loading, error, data } = useEventQuery({
+  const { loading, error, data } = useEventPageQuery({
     // TODO: dynamically pass current UserId
     variables: { eventId, userId: 1 },
     skip: !!event,

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -12,6 +12,7 @@ export interface EventPageProps {
   onBackButtonClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   onButtonClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   isReview?: boolean;
+  isJoined?: boolean;
 }
 
 export const EventPage = ({
@@ -21,18 +22,21 @@ export const EventPage = ({
   onButtonClick,
   eventImageURL,
   isReview = false,
+  isJoined = false,
   buttonType,
 }: EventPageProps) => {
   const { id } = useParams<{ id: string }>();
   const eventId = parseInt(id);
 
   const { loading, error, data } = useEventQuery({
-    variables: { id: eventId },
+    // TODO: dynamically pass current UserId
+    variables: { eventId, participatingEventUserId: 1 },
     skip: !!event,
   });
 
   if (!loading && data) {
     event = data.event;
+    isJoined = data.participatingEvent;
   }
 
   if (error) {
@@ -52,6 +56,7 @@ export const EventPage = ({
           event={event}
           handleMullButton={onButtonClick}
           isReview={isReview}
+          isJoined={isJoined}
           buttonType={buttonType}
         />
       </div>

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -6,7 +6,6 @@ import '../home-discover.scss';
 
 export const DiscoverPage = ({ history }) => {
   const { data } = useDiscoverEventsQuery({
-    fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
     variables: { userId: 1 },
   });
@@ -16,6 +15,7 @@ export const DiscoverPage = ({ history }) => {
     var eventCards = events.map((event, index) => (
       <EventCard
         key={`discover-${index}`}
+        isJoined={false}
         event={event}
         onClick={() => history.push(`/events/${event.id}`)}
       />

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -17,6 +17,7 @@ export const MyEventsPage = ({ history }) => {
     var eventCards = events.map((event, index) => (
       <EventCard
         key={`myEvents-${index}`}
+        isJoined={true}
         event={event}
         onClick={() => history.push(`/events/${event.id}`)}
       />

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -6,7 +6,6 @@ import '../home-discover.scss';
 
 export const MyEventsPage = ({ history }) => {
   const { data } = useOwnedEventsQuery({
-    fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
     variables: { userId: 1 },
   });

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -15,6 +15,7 @@ export const UpcomingPage = ({ history }) => {
     var eventCards = events.map((event, index) => (
       <EventCard
         key={`upcoming-${index}`}
+        isJoined={true}
         event={event}
         onClick={() => history.push(`/events/${event.id}`)}
       />

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -6,7 +6,6 @@ import '../home-discover.scss';
 
 export const UpcomingPage = ({ history }) => {
   const { data } = useParticipantEventsQuery({
-    fetchPolicy: 'network-only',
     // TODO: dynamically pass current UserId
     variables: { userId: 1 },
   });

--- a/apps/mull-ui/src/constants.ts
+++ b/apps/mull-ui/src/constants.ts
@@ -29,7 +29,7 @@ export const dummyProfilePictures: string[] = [
 ];
 
 export const dummyEvent: ISerializedEvent = {
-  id: 1,
+  id: '1',
   title: 'Test title',
   description:
     'Lorem ipsum dolor sit amet, regione invidunt democritum vim in, movet antiopam gubergren ne per. Est nibh magna scribentur ea, vel te munere deseruisse disputationi, eros meis ludus ne sea. Odio prompta legendos in sea, ut mei scripta labores theophrastus, id molestie probatus periculis mea. Noluisse invenire splendide sed ne, at erat quando laudem nec, possim apeirian vix at. At eam animal efficiendi interpretaris, eirmod offendit adversarium per et, summo qualisque efficiendi in has. Vel detraxit accusata ea.',

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -141,7 +141,7 @@ export type Query = {
   events: Array<Event>;
   getAutocompletedLocations: Array<Scalars['String']>;
   hostEvents: Array<Event>;
-  participatingEvent: Scalars['Boolean'];
+  isParticipant: Scalars['Boolean'];
   participatingEvents: Array<Event>;
   user: User;
   users: Array<User>;
@@ -173,7 +173,7 @@ export type QueryHostEventsArgs = {
 };
 
 
-export type QueryParticipatingEventArgs = {
+export type QueryIsParticipantArgs = {
   eventId: Scalars['Int'];
   userId: Scalars['Int'];
 };
@@ -365,13 +365,13 @@ export type AutocompletedLocationsQuery = (
 
 export type EventPageQueryVariables = Exact<{
   eventId: Scalars['Int'];
-  participatingEventUserId: Scalars['Int'];
+  userId: Scalars['Int'];
 }>;
 
 
 export type EventPageQuery = (
   { __typename?: 'Query' }
-  & Pick<Query, 'participatingEvent'>
+  & Pick<Query, 'isParticipant'>
   & { event: (
     { __typename?: 'Event' }
     & EventContentFragment

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -108,9 +108,9 @@ export type MutationJoinEventArgs = {
 };
 
 
-export type MutationLeaveEventArgs = {
-  eventId: Scalars['Float'];
-  userId: Scalars['Float'];
+export type MutationRemoveParticipantFromEventArgs = {
+  eventId: Scalars['Int'];
+  userId: Scalars['Int'];
 };
 
 
@@ -141,7 +141,8 @@ export type Query = {
   events: Array<Event>;
   getAutocompletedLocations: Array<Scalars['String']>;
   hostEvents: Array<Event>;
-  participantEvents: Array<Event>;
+  participatingEvent: Scalars['Boolean'];
+  participatingEvents: Array<Event>;
   user: User;
   users: Array<User>;
 };
@@ -172,7 +173,13 @@ export type QueryHostEventsArgs = {
 };
 
 
-export type QueryParticipantEventsArgs = {
+export type QueryParticipatingEventArgs = {
+  eventId: Scalars['Int'];
+  userId: Scalars['Int'];
+};
+
+
+export type QueryParticipatingEventsArgs = {
   userId: Scalars['Int'];
 };
 
@@ -270,8 +277,29 @@ export type LoginMutation = (
   ) }
 );
 
-export type EventQueryVariables = Exact<{
-  id: Scalars['Int'];
+export type JoinEventMutationVariables = Exact<{
+  eventId: Scalars['Int'];
+  userId: Scalars['Int'];
+}>;
+
+export type JoinEventMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'addParticipantToEvent'>
+);
+
+export type RemoveJoinedEventMutationVariables = Exact<{
+  eventId: Scalars['Int'];
+  userId: Scalars['Int'];
+}>;
+
+
+export type RemoveJoinedEventMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'removeParticipantFromEvent'>
+);
+
+export type FindSpecificEventQueryVariables = Exact<{
+  eventId: Scalars['Int'];
 }>;
 
 
@@ -335,7 +363,36 @@ export type AutocompletedLocationsQuery = (
   & Pick<Query, 'getAutocompletedLocations'>
 );
 
+export type EventPageQueryVariables = Exact<{
+  eventId: Scalars['Int'];
+  participatingEventUserId: Scalars['Int'];
+}>;
 
+
+export type EventPageQuery = (
+  { __typename?: 'Query' }
+  & Pick<Query, 'participatingEvent'>
+  & { event: (
+    { __typename?: 'Event' }
+    & Pick<Event, 'id' | 'title' | 'description' | 'startDate' | 'endDate' | 'restriction'>
+  ) }
+);
+
+export type EventContentFragment = (
+  { __typename?: 'Event' }
+  & Pick<Event, 'id' | 'title' | 'description' | 'startDate' | 'endDate' | 'restriction'>
+);
+
+export const EventContentFragmentDoc = gql`
+    fragment EventContent on Event {
+  id
+  title
+  description
+  startDate
+  endDate
+  restriction
+}
+    `;
 export const CreateEventDocument = gql`
     mutation CreateEvent($event: CreateEventInput!) {
   createEvent(event: $event) {
@@ -447,6 +504,18 @@ export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutati
  *
  * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
  * When your component renders, `useLoginMutation` returns a tuple that includes:
+export const JoinEventDocument = gql`
+    mutation JoinEvent($eventId: Int!, $userId: Int!) {
+  addParticipantToEvent(eventId: $eventId, userId: $userId)
+}
+    `;
+export type JoinEventMutationFn = Apollo.MutationFunction<JoinEventMutation, JoinEventMutationVariables>;
+
+/**
+ * __useJoinEventMutation__
+ *
+ * To run a mutation, you first call `useJoinEventMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useJoinEventMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -374,7 +374,7 @@ export type EventPageQuery = (
   & Pick<Query, 'participatingEvent'>
   & { event: (
     { __typename?: 'Event' }
-    & Pick<Event, 'id' | 'title' | 'description' | 'startDate' | 'endDate' | 'restriction'>
+    & EventContentFragment
   ) }
 );
 

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -287,13 +287,13 @@ export type JoinEventMutation = (
   & Pick<Mutation, 'addParticipantToEvent'>
 );
 
-export type RemoveJoinedEventMutationVariables = Exact<{
+export type LeaveEventMutationVariables = Exact<{
   eventId: Scalars['Int'];
   userId: Scalars['Int'];
 }>;
 
 
-export type RemoveJoinedEventMutation = (
+export type LeaveEventMutation = (
   { __typename?: 'Mutation' }
   & Pick<Mutation, 'removeParticipantFromEvent'>
 );
@@ -534,9 +534,54 @@ export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginM
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
-export const EventDocument = gql`
-    query Event($id: Int!) {
-  event(id: $id) {
+/**
+ * const [joinEventMutation, { data, loading, error }] = useJoinEventMutation({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useJoinEventMutation(baseOptions?: Apollo.MutationHookOptions<JoinEventMutation, JoinEventMutationVariables>) {
+        return Apollo.useMutation<JoinEventMutation, JoinEventMutationVariables>(JoinEventDocument, baseOptions);
+      }
+export type JoinEventMutationHookResult = ReturnType<typeof useJoinEventMutation>;
+export type JoinEventMutationResult = Apollo.MutationResult<JoinEventMutation>;
+export type JoinEventMutationOptions = Apollo.BaseMutationOptions<JoinEventMutation, JoinEventMutationVariables>;
+export const LeaveEventDocument = gql`
+    mutation LeaveEvent($eventId: Int!, $userId: Int!) {
+  removeParticipantFromEvent(eventId: $eventId, userId: $userId)
+}
+    `;
+export type LeaveEventMutationFn = Apollo.MutationFunction<LeaveEventMutation, LeaveEventMutationVariables>;
+
+/**
+ * __useLeaveEventMutation__
+ *
+ * To run a mutation, you first call `useLeaveEventMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLeaveEventMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [leaveEventMutation, { data, loading, error }] = useLeaveEventMutation({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useLeaveEventMutation(baseOptions?: Apollo.MutationHookOptions<LeaveEventMutation, LeaveEventMutationVariables>) {
+        return Apollo.useMutation<LeaveEventMutation, LeaveEventMutationVariables>(LeaveEventDocument, baseOptions);
+      }
+export type LeaveEventMutationHookResult = ReturnType<typeof useLeaveEventMutation>;
+export type LeaveEventMutationResult = Apollo.MutationResult<LeaveEventMutation>;
+export type LeaveEventMutationOptions = Apollo.BaseMutationOptions<LeaveEventMutation, LeaveEventMutationVariables>;
+export const FindSpecificEventDocument = gql`
+    query FindSpecificEvent($eventId: Int!) {
+  event(id: $eventId) {
     id
     title
     description

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -103,12 +103,12 @@ export type MutationDeleteUserArgs = {
 
 
 export type MutationJoinEventArgs = {
-  eventId: Scalars['Float'];
-  userId: Scalars['Float'];
+  eventId: Scalars['Int'];
+  userId: Scalars['Int'];
 };
 
 
-export type MutationRemoveParticipantFromEventArgs = {
+export type MutationLeaveEventArgs = {
   eventId: Scalars['Int'];
   userId: Scalars['Int'];
 };
@@ -142,7 +142,7 @@ export type Query = {
   getAutocompletedLocations: Array<Scalars['String']>;
   hostEvents: Array<Event>;
   isParticipant: Scalars['Boolean'];
-  participatingEvents: Array<Event>;
+  participantEvents: Array<Event>;
   user: User;
   users: Array<User>;
 };
@@ -179,7 +179,7 @@ export type QueryIsParticipantArgs = {
 };
 
 
-export type QueryParticipatingEventsArgs = {
+export type QueryParticipantEventsArgs = {
   userId: Scalars['Int'];
 };
 
@@ -282,9 +282,10 @@ export type JoinEventMutationVariables = Exact<{
   userId: Scalars['Int'];
 }>;
 
+
 export type JoinEventMutation = (
   { __typename?: 'Mutation' }
-  & Pick<Mutation, 'addParticipantToEvent'>
+  & Pick<Mutation, 'joinEvent'>
 );
 
 export type LeaveEventMutationVariables = Exact<{
@@ -295,11 +296,11 @@ export type LeaveEventMutationVariables = Exact<{
 
 export type LeaveEventMutation = (
   { __typename?: 'Mutation' }
-  & Pick<Mutation, 'removeParticipantFromEvent'>
+  & Pick<Mutation, 'leaveEvent'>
 );
 
-export type FindSpecificEventQueryVariables = Exact<{
-  eventId: Scalars['Int'];
+export type EventQueryVariables = Exact<{
+  id: Scalars['Int'];
 }>;
 
 
@@ -504,18 +505,6 @@ export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutati
  *
  * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
  * When your component renders, `useLoginMutation` returns a tuple that includes:
-export const JoinEventDocument = gql`
-    mutation JoinEvent($eventId: Int!, $userId: Int!) {
-  addParticipantToEvent(eventId: $eventId, userId: $userId)
-}
-    `;
-export type JoinEventMutationFn = Apollo.MutationFunction<JoinEventMutation, JoinEventMutationVariables>;
-
-/**
- * __useJoinEventMutation__
- *
- * To run a mutation, you first call `useJoinEventMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useJoinEventMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
@@ -534,7 +523,24 @@ export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginM
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
+export const JoinEventDocument = gql`
+    mutation JoinEvent($eventId: Int!, $userId: Int!) {
+  joinEvent(eventId: $eventId, userId: $userId)
+}
+    `;
+export type JoinEventMutationFn = Apollo.MutationFunction<JoinEventMutation, JoinEventMutationVariables>;
+
 /**
+ * __useJoinEventMutation__
+ *
+ * To run a mutation, you first call `useJoinEventMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useJoinEventMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
  * const [joinEventMutation, { data, loading, error }] = useJoinEventMutation({
  *   variables: {
  *      eventId: // value for 'eventId'
@@ -550,7 +556,7 @@ export type JoinEventMutationResult = Apollo.MutationResult<JoinEventMutation>;
 export type JoinEventMutationOptions = Apollo.BaseMutationOptions<JoinEventMutation, JoinEventMutationVariables>;
 export const LeaveEventDocument = gql`
     mutation LeaveEvent($eventId: Int!, $userId: Int!) {
-  removeParticipantFromEvent(eventId: $eventId, userId: $userId)
+  leaveEvent(eventId: $eventId, userId: $userId)
 }
     `;
 export type LeaveEventMutationFn = Apollo.MutationFunction<LeaveEventMutation, LeaveEventMutationVariables>;
@@ -579,9 +585,9 @@ export function useLeaveEventMutation(baseOptions?: Apollo.MutationHookOptions<L
 export type LeaveEventMutationHookResult = ReturnType<typeof useLeaveEventMutation>;
 export type LeaveEventMutationResult = Apollo.MutationResult<LeaveEventMutation>;
 export type LeaveEventMutationOptions = Apollo.BaseMutationOptions<LeaveEventMutation, LeaveEventMutationVariables>;
-export const FindSpecificEventDocument = gql`
-    query FindSpecificEvent($eventId: Int!) {
-  event(id: $eventId) {
+export const EventDocument = gql`
+    query Event($id: Int!) {
+  event(id: $id) {
     id
     title
     description
@@ -766,3 +772,38 @@ export function useAutocompletedLocationsLazyQuery(baseOptions?: Apollo.LazyQuer
 export type AutocompletedLocationsQueryHookResult = ReturnType<typeof useAutocompletedLocationsQuery>;
 export type AutocompletedLocationsLazyQueryHookResult = ReturnType<typeof useAutocompletedLocationsLazyQuery>;
 export type AutocompletedLocationsQueryResult = Apollo.QueryResult<AutocompletedLocationsQuery, AutocompletedLocationsQueryVariables>;
+export const EventPageDocument = gql`
+    query EventPage($eventId: Int!, $userId: Int!) {
+  isParticipant(eventId: $eventId, userId: $userId)
+  event(id: $eventId) {
+    ...EventContent
+  }
+}
+    ${EventContentFragmentDoc}`;
+
+/**
+ * __useEventPageQuery__
+ *
+ * To run a query within a React component, call `useEventPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useEventPageQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useEventPageQuery(baseOptions: Apollo.QueryHookOptions<EventPageQuery, EventPageQueryVariables>) {
+        return Apollo.useQuery<EventPageQuery, EventPageQueryVariables>(EventPageDocument, baseOptions);
+      }
+export function useEventPageLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventPageQuery, EventPageQueryVariables>) {
+          return Apollo.useLazyQuery<EventPageQuery, EventPageQueryVariables>(EventPageDocument, baseOptions);
+        }
+export type EventPageQueryHookResult = ReturnType<typeof useEventPageQuery>;
+export type EventPageLazyQueryHookResult = ReturnType<typeof useEventPageLazyQuery>;
+export type EventPageQueryResult = Apollo.QueryResult<EventPageQuery, EventPageQueryVariables>;

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -31,6 +31,6 @@ mutation JoinEvent($eventId: Int!, $userId: Int!) {
 }
 
 # User leaves an event
-mutation RemoveJoinedEvent($eventId: Int!, $userId: Int!) {
+mutation LeaveEvent($eventId: Int!, $userId: Int!) {
   removeParticipantFromEvent(eventId: $eventId, userId: $userId)
 }

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -25,4 +25,12 @@ mutation Login($loginInput: LoginInput!) {
   login(loginInput: $loginInput) {
     accessToken
   }
+# User joins an event
+mutation JoinEvent($eventId: Int!, $userId: Int!) {
+  addParticipantToEvent(eventId: $eventId, userId: $userId)
+}
+
+# User leaves an event
+mutation RemoveJoinedEvent($eventId: Int!, $userId: Int!) {
+  removeParticipantFromEvent(eventId: $eventId, userId: $userId)
 }

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -25,12 +25,14 @@ mutation Login($loginInput: LoginInput!) {
   login(loginInput: $loginInput) {
     accessToken
   }
+}
+
 # User joins an event
 mutation JoinEvent($eventId: Int!, $userId: Int!) {
-  addParticipantToEvent(eventId: $eventId, userId: $userId)
+  joinEvent(eventId: $eventId, userId: $userId)
 }
 
 # User leaves an event
 mutation LeaveEvent($eventId: Int!, $userId: Int!) {
-  removeParticipantFromEvent(eventId: $eventId, userId: $userId)
+  leaveEvent(eventId: $eventId, userId: $userId)
 }

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -59,12 +59,7 @@ query EventPage($eventId: Int!, $participatingEventUserId: Int!) {
   participatingEvent(eventId: $eventId, userId: $participatingEventUserId)
 
   event(id: $eventId) {
-    id
-    title
-    description
-    startDate
-    endDate
-    restriction
+    ...EventContent
   }
 }
 

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -53,3 +53,26 @@ query ParticipantEvents($userId: Int!) {
 query AutocompletedLocations($userInput: String!) {
   getAutocompletedLocations(userInput: $userInput)
 }
+
+# Find events by Id and finds participating events of user
+query EventPage($eventId: Int!, $participatingEventUserId: Int!) {
+  participatingEvent(eventId: $eventId, userId: $participatingEventUserId)
+
+  event(id: $eventId) {
+    id
+    title
+    description
+    startDate
+    endDate
+    restriction
+  }
+}
+
+fragment EventContent on Event {
+  id
+  title
+  description
+  startDate
+  endDate
+  restriction
+}

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -55,8 +55,8 @@ query AutocompletedLocations($userInput: String!) {
 }
 
 # Find events by Id and finds participating events of user
-query EventPage($eventId: Int!, $participatingEventUserId: Int!) {
-  participatingEvent(eventId: $eventId, userId: $participatingEventUserId)
+query EventPage($eventId: Int!, $userId: Int!) {
+  isParticipant(eventId: $eventId, userId: $userId)
 
   event(id: $eventId) {
     ...EventContent

--- a/apps/mull-ui/src/main.tsx
+++ b/apps/mull-ui/src/main.tsx
@@ -26,6 +26,11 @@ const client = new ApolloClient({
     uri: `${environment.backendUrl}/graphql`,
   }),
   cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'network-only',
+    },
+  },
 });
 
 ReactDOM.render(

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -41,7 +41,8 @@ export interface IEvent {
   location?: ILocation;
 }
 
-export interface ISerializedEvent extends Omit<IEvent, 'startDate' | 'endDate'> {
+export interface ISerializedEvent extends Omit<IEvent, 'startDate' | 'endDate' | 'id'> {
+  id: string;
   startDate: string;
   endDate: string;
 }


### PR DESCRIPTION
This PR closes #66 

To properly test this PR you will need to set up your database such that User with id 1: 
- Is not involved in at least 1 event
 
**Steps to test joining events**
1. Make sure to run `npm i ` on the project to pickup the new dependencies 
2. Run `npm run gen-graphql` to generate the `graphql.tsx`
1. Run `nx serve mull-api` and `nx serve mull-ui`
2. Go to `http://localhost:4200/home/discover`
3. Join an event
3.a By clicking on the join event button on the event card
3.b By clicking on the event card, it brings you to the preview page for the event. Click on "Join" button on the event preview page 

**Steps to run the E2E tests:**
1. Make sure to run `npm i ` on the project to pickup the new dependencies 
1. Run the server `nx serve mull-api`
1. In the root directory run  `nx e2e mull-ui-e2e --watch` ( Cypress takes some time to open up)