### PR TITLE
TASK-26: setup database seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [Running a local database for development](#running-a-local-database-for-development)
     - [Working with GraphQL on the Frontend](#working-with-graphql-on-the-frontend)
     - [Building and Serving the application for production](#building-and-serving-the-application-for-production)
+  - [Populate database](#populate-database)
   - [Travis CI](#travis-ci)
     - [Scripts](#scripts)
   - [Troubleshooting](#troubleshooting)
@@ -71,9 +72,9 @@ Some secrets and sensitive configuration files are needed to properly operate ce
 1. Add an .env file with the required credentials in the root of the project (see `docs-and-resources` channel on slack for credentials):
 
    ```properties
-   DB_HOST=<host>
-   DB_USERNAME=<username>
-   DB_PASSWORD=<password>
+   TYPEORM_HOST=<host>
+   TYPEORM_USERNAME=<username>
+   TYPEORM_PASSWORD=<password>
    ...
    ```
 
@@ -213,6 +214,20 @@ To stop the container whilst keeping the database changes, run `docker stop mull
       - Add the `-S` option if using HTTPS
 1. Serve the production backend:
    - `node dist/apps/mull-api/main.js`
+
+### Populate database
+
+You can populate the database with random values:
+
+Prerequisite:
+
+- Update the .env with what's on drive
+
+seeding:
+
+1. Start the database, if running locally
+1. Run `npm run start mull-api` to update the columns (You don't have to have this running afte updating)
+1. Run `npm run seed:run`
 
 ## Travis CI
 

--- a/apps/mull-api/src/app/entities/event.entity.ts
+++ b/apps/mull-api/src/app/entities/event.entity.ts
@@ -40,7 +40,7 @@ export class Event implements IEvent {
   endDate: Date;
 
   @Field()
-  @Column({length: '2048' })
+  @Column({ length: '2048' })
   description: string;
 
   @OneToOne(/* istanbul ignore next */ () => Media)

--- a/apps/mull-api/src/app/entities/event.entity.ts
+++ b/apps/mull-api/src/app/entities/event.entity.ts
@@ -28,7 +28,7 @@ export class Event implements IEvent {
   id: number;
 
   @Field()
-  @Column()
+  @Column({ length: '64' })
   title: string;
 
   @Field()
@@ -40,7 +40,7 @@ export class Event implements IEvent {
   endDate: Date;
 
   @Field()
-  @Column()
+  @Column({length: '2048' })
   description: string;
 
   @OneToOne(/* istanbul ignore next */ () => Media)

--- a/apps/mull-api/src/database/factories/event.factory.ts
+++ b/apps/mull-api/src/database/factories/event.factory.ts
@@ -2,18 +2,22 @@ import * as Faker from 'faker';
 import { define, factory } from 'typeorm-seeding';
 import { Event, Media, User } from '../../app/entities';
 
+const maxNumberOfWords = 6;
+const maxCoHostNumber = 5;
+const maxParticipants = 30;
+
 define(Event, (faker: typeof Faker) => {
   const event = new Event();
 
-  event.title = faker.lorem.lines();
+  event.title = faker.lorem.words(maxNumberOfWords);
   event.description = faker.lorem.paragraph();
   event.startDate = faker.date.future();
   event.endDate = faker.date.future();
   event.restriction = faker.random.number(3);
 
   event.host = factory(User)() as any;
-  event.coHosts = factory(User)().createMany(faker.random.number(5)) as any;
-  event.participants = factory(User)().createMany(faker.random.number(30)) as any;
+  event.coHosts = factory(User)().createMany(faker.random.number(maxCoHostNumber)) as any;
+  event.participants = factory(User)().createMany(faker.random.number(maxParticipants)) as any;
   event.image = factory(Media)() as any;
 
   return event;

--- a/apps/mull-api/src/database/factories/event.factory.ts
+++ b/apps/mull-api/src/database/factories/event.factory.ts
@@ -5,7 +5,6 @@ import { Event, Media, User } from '../../app/entities';
 define(Event, (faker: typeof Faker) => {
   const event = new Event();
 
-  // event.id = faker.random.number();
   event.title = faker.lorem.lines();
   event.description = faker.lorem.paragraph();
   event.startDate = faker.date.future();

--- a/apps/mull-api/src/database/factories/event.factory.ts
+++ b/apps/mull-api/src/database/factories/event.factory.ts
@@ -1,18 +1,19 @@
-import * as Faker from 'faker';
+import faker = require('faker');
 import { define, factory } from 'typeorm-seeding';
 import { Event, Media, User } from '../../app/entities';
 
-const maxNumberOfWords = 6;
-const maxCoHostNumber = 5;
-const maxParticipants = 30;
-
-define(Event, (faker: typeof Faker) => {
+define(Event, () => {
+  const maxNumberOfWords = 6;
+  const maxCoHostNumber = 5;
+  const maxParticipants = 30;
+  const startDate = faker.date.soon(faker.random.number(5));
+  const endDate = faker.date.soon(6 + faker.random.number(5));
   const event = new Event();
 
   event.title = faker.lorem.words(maxNumberOfWords);
   event.description = faker.lorem.paragraph();
-  event.startDate = faker.date.future();
-  event.endDate = faker.date.future();
+  event.startDate = startDate;
+  event.endDate = endDate;
   event.restriction = faker.random.number(3);
 
   event.host = factory(User)() as any;

--- a/apps/mull-api/src/database/factories/event.factory.ts
+++ b/apps/mull-api/src/database/factories/event.factory.ts
@@ -1,0 +1,21 @@
+import * as Faker from 'faker';
+import { define, factory } from 'typeorm-seeding';
+import { Event, Media, User } from '../../app/entities';
+
+define(Event, (faker: typeof Faker) => {
+  const event = new Event();
+
+  // event.id = faker.random.number();
+  event.title = faker.lorem.lines();
+  event.description = faker.lorem.paragraph();
+  event.startDate = faker.date.future();
+  event.endDate = faker.date.future();
+  event.restriction = faker.random.number(3);
+
+  event.host = factory(User)() as any;
+  event.coHosts = factory(User)().createMany(faker.random.number(5)) as any;
+  event.participants = factory(User)().createMany(faker.random.number(30)) as any;
+  event.image = factory(Media)() as any;
+
+  return event;
+});

--- a/apps/mull-api/src/database/factories/media.factory.ts
+++ b/apps/mull-api/src/database/factories/media.factory.ts
@@ -5,7 +5,6 @@ import { Media } from '../../app/entities';
 define(Media, (faker: typeof Faker) => {
   const media_type = faker.random.arrayElement(['jpeg', 'jpg', 'png']);
   const media = new Media(media_type);
-  // media.id = faker.random.number();
 
   return media;
 });

--- a/apps/mull-api/src/database/factories/media.factory.ts
+++ b/apps/mull-api/src/database/factories/media.factory.ts
@@ -3,8 +3,8 @@ import { define } from 'typeorm-seeding';
 import { Media } from '../../app/entities';
 
 define(Media, (faker: typeof Faker) => {
-  const media_type = faker.random.arrayElement(['jpeg', 'jpg', 'png']);
-  const media = new Media(media_type);
+  const mediaType = faker.random.arrayElement(['jpeg', 'jpg', 'png']);
+  const media = new Media(mediaType);
 
   return media;
 });

--- a/apps/mull-api/src/database/factories/media.factory.ts
+++ b/apps/mull-api/src/database/factories/media.factory.ts
@@ -1,0 +1,11 @@
+import * as Faker from 'faker';
+import { define } from 'typeorm-seeding';
+import { Media } from '../../app/entities';
+
+define(Media, (faker: typeof Faker) => {
+  const media_type = faker.random.arrayElement(['jpeg', 'jpg', 'png']);
+  const media = new Media(media_type);
+  // media.id = faker.random.number();
+
+  return media;
+});

--- a/apps/mull-api/src/database/factories/user.factory.ts
+++ b/apps/mull-api/src/database/factories/user.factory.ts
@@ -6,7 +6,6 @@ import { Media, User } from '../../app/entities';
 define(User, (faker: typeof Faker) => {
   const user = new User();
 
-  // user.id = faker.random.number();
   user.password = faker.internet.password();
   user.email = faker.internet.email();
   user.name = faker.name.firstName() + ' ' + faker.name.lastName();

--- a/apps/mull-api/src/database/factories/user.factory.ts
+++ b/apps/mull-api/src/database/factories/user.factory.ts
@@ -1,9 +1,9 @@
 import { RegistrationMethod } from '@mull/types';
-import * as Faker from 'faker';
 import { define, factory } from 'typeorm-seeding';
 import { Media, User } from '../../app/entities';
+import faker = require('faker');
 
-define(User, (faker: typeof Faker) => {
+define(User, () => {
   const user = new User();
 
   user.password = faker.internet.password();

--- a/apps/mull-api/src/database/factories/user.factory.ts
+++ b/apps/mull-api/src/database/factories/user.factory.ts
@@ -1,0 +1,23 @@
+import { RegistrationMethod } from '@mull/types';
+import * as Faker from 'faker';
+import { define, factory } from 'typeorm-seeding';
+import { Media, User } from '../../app/entities';
+
+define(User, (faker: typeof Faker) => {
+  const user = new User();
+
+  // user.id = faker.random.number();
+  user.password = faker.internet.password();
+  user.email = faker.internet.email();
+  user.name = faker.name.firstName() + ' ' + faker.name.lastName();
+  user.description = faker.lorem.sentence();
+  user.dob = faker.date.past();
+
+  user.timezone = faker.lorem.word();
+  user.registrationMethod = faker.random.objectElement<RegistrationMethod>(RegistrationMethod);
+  user.tokenVersion = 0;
+
+  user.avatar = factory(Media)() as any;
+
+  return user;
+});

--- a/apps/mull-api/src/database/seeders/database.seeder.ts
+++ b/apps/mull-api/src/database/seeders/database.seeder.ts
@@ -1,0 +1,35 @@
+import { Connection } from 'typeorm';
+import { Factory, Seeder } from 'typeorm-seeding';
+import { Event } from '../../app/entities';
+
+/**
+ * For each user, add the next 3 users with greater id's as friends with the exception of the last 2 users
+ * @param connection
+ */
+/* eslint-disable @typescript-eslint/camelcase */
+const createFriends = async (connection: Connection) => {
+  const a: any[] = await connection.query('SELECT id FROM `mull-dev`.user');
+  for (let i = 0; i < a.length - 3; i++) {
+    const query = connection
+      .createQueryBuilder()
+      .insert()
+      .into('friends')
+      .values([
+        { userId_1: a[i].id, userId_2: a[i + 1].id },
+        { userId_1: a[i].id, userId_2: a[i + 2].id },
+        { userId_1: a[i].id, userId_2: a[i + 3].id },
+      ]);
+
+    const [sql, args] = query.getQueryAndParameters();
+    const nsql = sql.replace('INSERT INTO', 'INSERT IGNORE INTO');
+
+    await connection.manager.query(nsql, args);
+  }
+};
+
+export default class DatabaseSeeder implements Seeder {
+  public async run(factory: Factory, connection: Connection): Promise<any> {
+    await factory(Event)().createMany(10);
+    await createFriends(connection);
+  }
+}

--- a/apps/mull-api/src/database/seeders/database.seeder.ts
+++ b/apps/mull-api/src/database/seeders/database.seeder.ts
@@ -1,6 +1,9 @@
 import { Connection } from 'typeorm';
 import { Factory, Seeder } from 'typeorm-seeding';
 import { Event } from '../../app/entities';
+import faker = require('faker');
+
+faker.seed(123);
 
 /**
  * For each user, add the next 3 users with greater id's as friends with the exception of the last 2 users

--- a/apps/mull-api/src/environments/environment.prod.ts
+++ b/apps/mull-api/src/environments/environment.prod.ts
@@ -4,9 +4,9 @@ export const environment = {
   production: true,
 
   db: {
-    host: process.env.DB_HOST,
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
+    host: process.env.TYPEORM_HOST,
+    username: process.env.TYPEORM_USERNAME,
+    password: process.env.TYPEORM_PASSWORD,
   },
   auth: {
     google: {

--- a/apps/mull-api/src/environments/environment.ts
+++ b/apps/mull-api/src/environments/environment.ts
@@ -7,7 +7,7 @@ export const environment = {
     host: process.env.TYPEORM_HOST,
     username: process.env.TYPEORM_USERNAME,
     password: process.env.TYPEORM_PASSWORD,
-    port: 3306
+    port: 3306,
   },
   auth: {
     google: {

--- a/apps/mull-api/src/environments/environment.ts
+++ b/apps/mull-api/src/environments/environment.ts
@@ -4,9 +4,10 @@ export const environment = {
   production: false,
 
   db: {
-    host: process.env.DB_HOST,
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
+    host: process.env.TYPEORM_HOST,
+    username: process.env.TYPEORM_USERNAME,
+    password: process.env.TYPEORM_PASSWORD,
+    port: 3306
   },
   auth: {
     google: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9784,7 +9784,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -9946,8 +9945,7 @@
     "cli-spinners": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
-      "dev": true
+      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA=="
     },
     "cli-table3": {
       "version": "0.6.0",
@@ -10069,8 +10067,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -11642,7 +11639,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       }
@@ -15717,8 +15713,7 @@
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -18233,7 +18228,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2"
       }
@@ -18753,8 +18747,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -19078,8 +19071,7 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "mysql": {
       "version": "2.18.1",
@@ -19942,7 +19934,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -22597,7 +22588,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -25579,6 +25569,186 @@
         }
       }
     },
+    "typeorm-seeding": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/typeorm-seeding/-/typeorm-seeding-1.6.1.tgz",
+      "integrity": "sha512-xJIW1pp72hv6npPqbQ7xDvawcDmS60EDUjK++UCfiqT0WE4xTzCn+QK1ZijLkD3GYCqFPuFt4nmeyRJn6VO2Vw==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "faker": "4.1.0",
+        "glob": "7.1.6",
+        "ora": "4.0.3",
+        "reflect-metadata": "0.1.13",
+        "yargs": "15.3.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "faker": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+          "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "ora": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
+          "integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.2.0",
+            "is-interactive": "^1.0.0",
+            "log-symbols": "^3.0.0",
+            "mute-stream": "0.0.8",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
@@ -26545,7 +26715,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "wait-on": "wait-on",
     "workspace-schematic": "nx workspace-schematic",
     "preinstall": "npx npm-force-resolutions",
-    "gen-graphql": "graphql-codegen --config codegen.yml"
+    "gen-graphql": "graphql-codegen --config codegen.yml",
+    "seed:config": "ts-node --project ./apps/mull-api/tsconfig.app.json -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js config",
+    "seed:run": "ts-node --project ./apps/mull-api/tsconfig.app.json -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed"
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
@@ -83,6 +85,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "~6.5.5",
     "typeorm": "^0.2.28",
+    "typeorm-seeding": "^1.6.1",
     "yup": "^0.29.3"
   },
   "devDependencies": {
@@ -91,6 +94,10 @@
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.9.0",
     "@graphql-codegen/cli": "1.20.0",
+    "@graphql-codegen/introspection": "1.18.1",
+    "@graphql-codegen/typescript": "1.20.0",
+    "@graphql-codegen/typescript-operations": "1.17.13",
+    "@graphql-codegen/typescript-react-apollo": "2.2.1",
     "@nestjs/schematics": "^7.0.0",
     "@nestjs/testing": "^7.0.0",
     "@nrwl/cypress": "10.1.0",
@@ -140,14 +147,11 @@
     "sonar-scanner": "^3.1.0",
     "ts-jest": "26.1.4",
     "ts-node": "~7.0.0",
+    "tsconfig-paths": "^3.9.0",
     "tslint": "~6.0.0",
     "typescript": "~3.9.3",
     "wait-on": "^5.2.0",
-    "workbox-cli": "^5.1.3",
-    "@graphql-codegen/typescript-operations": "1.17.13",
-    "@graphql-codegen/typescript-react-apollo": "2.2.1",
-    "@graphql-codegen/typescript": "1.20.0",
-    "@graphql-codegen/introspection": "1.18.1"
+    "workbox-cli": "^5.1.3"
   },
   "resolutions": {
     "graphql-upload": "^11.0.0"


### PR DESCRIPTION
closes #102 

Database seeding is now possible with the command npm run seed:run. This will allow to database to be populated automatically by running the command. It will: 

- assign a host for each event
- add participants to each of the events
- add friends to most users

**Steps to review PR**
1. Update your `.env` file
2. run `npm i`
3. Run the backend to update your database schema: `nx serve mull-api`
4. Run `npm run seed:run`

Note that the .env will now have to change to allow the seeding, please see the drive.