### PR TITLE
BUG-3: Clean up Test Console Warnings

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -75,7 +75,9 @@ export const App = () => {
                 <Route path={ROUTES.DISCOVER} component={DiscoverPage} />
                 <Route path={ROUTES.UPCOMING} component={UpcomingPage} />
                 <Route path={ROUTES.MY_EVENTS} component={MyEventsPage} />
-                <Route exact path={ROUTES.HOME} render={() => <Redirect to={ROUTES.DISCOVER} />} />
+                <Route exact path={ROUTES.HOME}>
+                  <Redirect to={ROUTES.DISCOVER} />
+                </Route>
               </SwipeableRoutes>
             </div>
           </Route>

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -14,7 +14,11 @@ export const DiscoverPage = ({ history }) => {
   if (data) {
     const events = (data.discoverEvents as unknown) as Partial<ISerializedEvent>[];
     var eventCards = events.map((event, index) => (
-      <EventCard key={index} event={event} onClick={() => history.push(`/events/${event.id}`)} />
+      <EventCard
+        key={`discover-${index}`}
+        event={event}
+        onClick={() => history.push(`/events/${event.id}`)}
+      />
     ));
   }
   return <div className="discover-page-tabs-container">{eventCards}</div>;

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -16,7 +16,11 @@ export const MyEventsPage = ({ history }) => {
       ISerializedEvent
     >[];
     var eventCards = events.map((event, index) => (
-      <EventCard key={index} event={event} onClick={() => history.push(`/events/${event.id}`)} />
+      <EventCard
+        key={`myEvents-${index}`}
+        event={event}
+        onClick={() => history.push(`/events/${event.id}`)}
+      />
     ));
   }
   return <div className="discover-page-tabs-container">{eventCards}</div>;

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -14,7 +14,11 @@ export const UpcomingPage = ({ history }) => {
   if (data) {
     const events = (data.participantEvents as unknown) as Partial<ISerializedEvent>[];
     var eventCards = events.map((event, index) => (
-      <EventCard key={index} event={event} onClick={() => history.push(`/events/${event.id}`)} />
+      <EventCard
+        key={`upcoming-${index}`}
+        event={event}
+        onClick={() => history.push(`/events/${event.id}`)}
+      />
     ));
   }
   return <div className="discover-page-tabs-container">{eventCards}</div>;

--- a/apps/mull-ui/src/app/pages/login/login.spec.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.spec.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
 import '@testing-library/jest-dom';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
@@ -40,7 +40,7 @@ describe('Login', () => {
 
     const utils = render(renderHelper(history));
     const submitButton = utils.container.querySelector('button.login');
-    await waitFor(() => {
+    await act(async () => {
       fireEvent.click(submitButton);
     });
 
@@ -57,20 +57,22 @@ describe('Login', () => {
     input = utils.getByLabelText('Password');
     fireEvent.change(input, { target: { value: 'password123' } });
     const submitButton = utils.container.querySelector('button[type="submit"]');
-    await waitFor(() => {
+    await act(async () => {
       fireEvent.click(submitButton);
     });
   });
 
   it('should redirect to OAuth providers', async () => {
-    const history = createMemoryHistory();
-    const oAuthProviders = ['Google', 'Facebook', 'Twitter'];
-    history.push(ROUTES.LOGIN);
+    await act(async () => {
+      const history = createMemoryHistory();
+      const oAuthProviders = ['Google', 'Facebook', 'Twitter'];
+      history.push(ROUTES.LOGIN);
 
-    const utils = render(renderHelper(history));
-    for (const provider of oAuthProviders) {
-      const oAuthButton = utils.getByText(`Continue with ${provider}`);
-      fireEvent.click(oAuthButton);
-    }
+      const utils = render(renderHelper(history));
+      for (const provider of oAuthProviders) {
+        const oAuthButton = utils.getByText(`Continue with ${provider}`);
+        fireEvent.click(oAuthButton);
+      }
+    });
   });
 });

--- a/apps/mull-ui/src/app/pages/login/login.spec.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.spec.tsx
@@ -14,11 +14,18 @@ describe('Login', () => {
     const userId = null,
       accessToken = null;
     const setAccessToken = jest.fn();
+    const { location } = window;
     // Stops tests from being redirected to OAuth Provider websites
-    delete window.location;
-    window.location = {
-      assign: jest.fn(),
-    } as any;
+    beforeEach(() => {
+      delete window.location;
+      window.location = {
+        assign: jest.fn(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    });
+    afterEach(() => {
+      window.location = location;
+    });
 
     return (
       <UserProvider value={{ userId, setUserId, accessToken, setAccessToken }}>

--- a/apps/mull-ui/src/app/pages/login/login.spec.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.spec.tsx
@@ -14,6 +14,11 @@ describe('Login', () => {
     const userId = null,
       accessToken = null;
     const setAccessToken = jest.fn();
+    // Stops tests from being redirected to OAuth Provider websites
+    delete window.location;
+    window.location = {
+      assign: jest.fn(),
+    } as any;
 
     return (
       <UserProvider value={{ userId, setUserId, accessToken, setAccessToken }}>
@@ -49,15 +54,15 @@ describe('Login', () => {
   });
 
   it('should submit a users login credentials', async () => {
-    const history = createMemoryHistory();
-    history.push(ROUTES.LOGIN);
-    const utils = render(renderHelper(history));
-    let input = utils.getByLabelText('Email');
-    fireEvent.change(input, { target: { value: 'test.email@email.com' } });
-    input = utils.getByLabelText('Password');
-    fireEvent.change(input, { target: { value: 'password123' } });
-    const submitButton = utils.container.querySelector('button[type="submit"]');
     await act(async () => {
+      const history = createMemoryHistory();
+      history.push(ROUTES.LOGIN);
+      const utils = render(renderHelper(history));
+      let input = utils.getByLabelText('Email');
+      fireEvent.change(input, { target: { value: 'test.email@email.com' } });
+      input = utils.getByLabelText('Password');
+      fireEvent.change(input, { target: { value: 'password123' } });
+      const submitButton = utils.container.querySelector('button[type="submit"]');
       fireEvent.click(submitButton);
     });
   });

--- a/apps/mull-ui/src/app/pages/register/register.spec.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.spec.tsx
@@ -1,7 +1,7 @@
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { RegistrationMethod } from '@mull/types';
 import '@testing-library/jest-dom';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
@@ -43,47 +43,48 @@ describe('Register', () => {
 
     const utils = render(renderHelper(history));
     const submitButton = utils.container.querySelector('button[type="submit"]');
-    await waitFor(() => {
+    await act(async () => {
       fireEvent.click(submitButton);
     });
-
     const error = utils.container.querySelector('span[class="error-message"]');
     expect(error).toHaveTextContent('Name is required.');
   });
 
   it('should submit a users login credentials', async () => {
-    const history = createMemoryHistory();
-    history.push(ROUTES.REGISTER);
-    const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: CreateUserDocument,
-          variables: {
-            user: {
-              name: 'John Doe',
-              email: 'abc@def.com',
-              password: 'abc123',
-              registrationMethod: RegistrationMethod.LOCAL,
+    await act(async () => {
+      const history = createMemoryHistory();
+      history.push(ROUTES.REGISTER);
+      const mocks: MockedResponse[] = [
+        {
+          request: {
+            query: CreateUserDocument,
+            variables: {
+              createUserInput: {
+                name: 'John Doe',
+                email: 'abc@def.com',
+                password: 'abc123',
+                registrationMethod: RegistrationMethod.LOCAL,
+              },
             },
           },
+          result: {
+            data: { createUser: { id: 10 } },
+          },
         },
-        result: {
-          data: { createUser: { id: 10 } },
-        },
-      },
-    ];
+      ];
 
-    const utils = render(renderHelper(history, mocks));
+      const utils = render(renderHelper(history, mocks));
 
-    let input = utils.getByLabelText('Name');
-    fireEvent.change(input, { target: { value: 'John' } });
-    input = utils.getByLabelText('Email');
-    fireEvent.change(input, { target: { value: 'test.email@email.com' } });
-    input = utils.getByLabelText('Password');
-    fireEvent.change(input, { target: { value: 'password123' } });
-    const submitButton = utils.container.querySelector('button[type="submit"]');
-    await waitFor(() => {
-      fireEvent.click(submitButton);
+      let input = utils.getByLabelText('Name');
+      fireEvent.change(input, { target: { value: 'John' } });
+      input = utils.getByLabelText('Email');
+      fireEvent.change(input, { target: { value: 'test.email@email.com' } });
+      input = utils.getByLabelText('Password');
+      fireEvent.change(input, { target: { value: 'password123' } });
+      const submitButton = utils.container.querySelector('button[type="submit"]');
+      await waitFor(() => {
+        fireEvent.click(submitButton);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #93 

This cleans up all the warnings while running tests except for one. This last warning is a result of our dependency on [React-Swipeable-Views](https://github.com/oliviertassinari/react-swipeable-views/issues/534).

I added a disable eslint to keep the code in the test cleaner. Without it I would have to mock all the functions in the window object and it would make the code longer and less readable. This was added on commit 23ae963

In general when a test updates some state the function updating state should be wrapped in `act`. 