### PR TITLE
SONARCLOUD: Fix Code Coverage and Code Duplication

### DIFF
--- a/apps/mull-ui/src/app/pages/messages/announcements/__snapshots__/announcements.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/messages/announcements/__snapshots__/announcements.spec.tsx.snap
@@ -163,51 +163,5 @@ exports[`Announcements should match snapshot 1`] = `
       </p>
     </div>
   </div>
-  <div
-    className="chat-container"
-  >
-    <p
-      className="announcement-time"
-    >
-      13:00 21/10/20
-    </p>
-    <div
-      className="current-user-chat-container"
-    >
-      <img
-        alt="user"
-        className="user-picture"
-        src="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-      />
-      <p
-        className="chat-bubble"
-      >
-        Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.
-      </p>
-    </div>
-  </div>
-  <div
-    className="chat-container"
-  >
-    <p
-      className="announcement-time"
-    >
-      13:00 21/10/20
-    </p>
-    <div
-      className="current-user-chat-container"
-    >
-      <img
-        alt="user"
-        className="user-picture"
-        src="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-      />
-      <p
-        className="chat-bubble"
-      >
-        Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.
-      </p>
-    </div>
-  </div>
 </div>
 `;

--- a/apps/mull-ui/src/app/pages/messages/announcements/announcements.tsx
+++ b/apps/mull-ui/src/app/pages/messages/announcements/announcements.tsx
@@ -55,20 +55,6 @@ export const AnnouncementsPage = () => {
         chatMessage="Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing
         industries for previewing layouts and visual mockups."
       />
-      <ChatBubble
-        isCurrentUser={true}
-        chatDate="13:00 21/10/20"
-        userPicture="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-        chatMessage="Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing
-        industries for previewing layouts and visual mockups."
-      />
-      <ChatBubble
-        isCurrentUser={true}
-        chatDate="13:00 21/10/20"
-        userPicture="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-        chatMessage="Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing
-        industries for previewing layouts and visual mockups."
-      />
     </div>
   );
 };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.links.scm=https://github.com/RGPosadas/Mull
 sonar.host.url=https://sonarcloud.io
 sonar.organization=rgposadas
 sonar.sources=libs, apps
-sonar.exclusions=**/*jest*.js,**/*spec*
+sonar.exclusions=**/*jest*.js,**/*spec*,**/mull-ui-e2e/**,**/database/**,**/environments/**,**/strategies/**, **/generated/**
 
 # Code coverage
 sonar.javascript.lcov.reportPaths=coverage/apps/mull-api/lcov.info,coverage/apps/mull-ui/lcov.info,coverage/libs/types/lcov.info


### PR DESCRIPTION
This PR aims to increase the code coverage by ignoring files that were not meant to be counted in the code coverage and decrease the code duplication by removing some filler chat bubbles in announcements as they are only static placeholders. 

Before: 
<img width="652" alt="Screen Shot 2021-01-29 at 11 48 12 AM" src="https://user-images.githubusercontent.com/38992971/106304238-1fb3f280-6229-11eb-828e-af1274e5dc9d.png">

After: 
<img width="652" alt="Screen Shot 2021-01-29 at 11 51 53 AM" src="https://user-images.githubusercontent.com/38992971/106304252-2478a680-6229-11eb-85bf-ddd5fa63f616.png">
