### PR TITLE
FIX: Convert raw SQL to TypeORM syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ To test all projects:
 nx run-many --target=test --all
 ```
 
+To test a specific file:
+
+```bash
+nx test <project> --test-file <file-name>
+```
+
 To test projects affected by your changes:
 
 ```bash

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -4,12 +4,7 @@ import { Repository } from 'typeorm';
 import { Event } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
 import { MockType } from '../user/user.service.spec';
-import {
-  mockAllEvents,
-  mockExpectedQueryReturn,
-  mockPartialEvent,
-  mockQueryReturn,
-} from './event.mockdata';
+import { mockAllEvents, mockPartialEvent } from './event.mockdata';
 import { EventService } from './event.service';
 import { CreateEventInput } from './inputs/event.input';
 
@@ -23,10 +18,14 @@ const mockEventRepository = () => ({
   delete: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
   save: jest.fn((event: Event) => event),
   createQueryBuilder: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     leftJoinAndSelect: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    getQuery: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockReturnValue(mockAllEvents[0]),
   })),
   query: jest.fn().mockReturnThis(),
@@ -177,10 +176,9 @@ describe('EventService', () => {
 
   it('should return all the events a user is not involved in', async () => {
     const userId = mockAllUsers[2].id;
-    repository.query.mockImplementation(() => mockQueryReturn);
     const foundEvents = await service.getEventsRecommendedToUser(userId);
-    expect(foundEvents).toEqual(mockExpectedQueryReturn);
-    expect(repository.query).toBeCalledTimes(1);
+    expect(foundEvents).toEqual(mockAllEvents[0]);
+    expect(repository.createQueryBuilder).toBeCalled();
   });
 
   it('should get an image', async () => {


### PR DESCRIPTION
This PR removes technical debt introduced in #154 by converting the raw SQL in `event.service.ts` into typeORM syntax.

Having all our queries use the ORM syntax will make our backend easier to maintain and update as new features are added.

I had to update a failing snapshot from develop. It is unrelated to this PR.

*Notes: Discover page only shows public events. This means events with `restriction = 0`