### PR TITLE
TASK-45: Authenticated Backend Routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 testem.log
 /typings
 /.env*
+cypress.env.json
 
 # System Files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ nx affected:test --base=origin/<base-branch>
 
 E2E testing is done thought the [Nx CLI](https://nx.dev/latest/react/cli/e2e), and uses [cypress](https://www.cypress.io/).
 
+Add a `cypress.env.json` in the `mull-ui-e2e` project. See `docs-and-resources` channel on slack for our secret key.
+
+```properties
+{
+   "ACCESS_TOKEN_SECRET": "<secret-key>"
+}
+...
+```
+
 To run e2e tests for a project:
 
 ```bash

--- a/apps/mull-api/src/app/auth/auth.guard.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.spec.ts
@@ -63,6 +63,7 @@ describe('AuthGuards', () => {
   });
   // This testing methodology for param decorators was found on the nestjs github repo
   // https://github.com/nestjs/nest/issues/1020
+  /* eslint-disable @typescript-eslint/ban-types, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
   describe('Auth Param Decorator', () => {
     function getParamDecoratorFactory(decorator: Function) {
       class Test {

--- a/apps/mull-api/src/app/auth/auth.guard.spec.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,81 @@
+import { createMock } from '@golevelup/nestjs-testing';
+import { ExecutionContext } from '@nestjs/common';
+import jwt from 'jsonwebtoken';
+import { AuthenticatedUser, AuthGuard } from './auth.guard';
+jest.mock('jsonwebtoken');
+const mockedJwt = jwt as jest.Mocked<typeof jwt>;
+
+describe('AuthGuards', () => {
+  describe('AuthGuard', () => {
+    let guard;
+    beforeEach(() => {
+      guard = new AuthGuard();
+    });
+
+    it('AuthGuard', () => {
+      expect(guard).toBeDefined();
+    });
+
+    it('Guard should return true with auth', () => {
+      const context = createMock<ExecutionContext>();
+
+      context.switchToHttp().getNext.mockReturnValue({
+        req: {
+          headers: {
+            authorization: 'auth',
+          },
+        },
+      });
+
+      mockedJwt.verify.mockImplementation(() => true);
+      expect(guard.canActivate(context)).toBeTruthy();
+    });
+
+    it('Guard should return false without auth', () => {
+      const context = createMock<ExecutionContext>();
+
+      context.switchToHttp().getNext.mockReturnValue({
+        req: {
+          headers: {
+            authorization: 'auth',
+          },
+        },
+      });
+
+      mockedJwt.verify.mockImplementation(() => false);
+      expect(guard.canActivate(context)).toBeFalsy();
+    });
+  });
+
+  describe('Auth Param Decorator', () => {
+    it('Auth param decorator should return with auth', () => {
+      const context = createMock<ExecutionContext>();
+
+      context.switchToHttp().getNext.mockReturnValue({
+        req: {
+          headers: {
+            authorization: 'auth',
+          },
+        },
+      });
+
+      mockedJwt.verify.mockImplementation(() => true);
+      expect(AuthenticatedUser.call(context)).toBeTruthy();
+    });
+
+    it('should return false with auth for param decorator', () => {
+      const context = createMock<ExecutionContext>();
+
+      context.switchToHttp().getNext.mockReturnValue({
+        req: {
+          headers: {
+            authorization: 'auth',
+          },
+        },
+      });
+
+      mockedJwt.verify.mockImplementation(() => false);
+      expect(AuthenticatedUser.call(context)).toThrow();
+    });
+  });
+});

--- a/apps/mull-api/src/app/auth/auth.guard.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.ts
@@ -1,4 +1,4 @@
-import { GqlContext, IAuthToken } from '@mull/types';
+import { IAuthToken } from '@mull/types';
 import {
   CanActivate,
   createParamDecorator,
@@ -6,7 +6,6 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import { GqlExecutionContext } from '@nestjs/graphql';
 import jwt from 'jsonwebtoken';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
@@ -14,8 +13,7 @@ import { environment } from '../../environments/environment';
 @Injectable()
 export class AuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
-    const ctx = GqlExecutionContext.create(context);
-    const accessToken = ctx.getContext<GqlContext>().req.headers.authorization.split(' ')[1];
+    const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
     try {
       return !!jwt.verify(accessToken, environment.jwt.accessSecret);
     } catch (err) {
@@ -25,8 +23,7 @@ export class AuthGuard implements CanActivate {
 }
 
 export const AuthenticatedUser = createParamDecorator((_, context: ExecutionContext): number => {
-  const ctx = GqlExecutionContext.create(context);
-  const accessToken = ctx.getContext<GqlContext>().req.headers.authorization.split(' ')[1];
+  const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
   try {
     const { id } = jwt.verify(accessToken, environment.jwt.accessSecret) as IAuthToken;
     return id;

--- a/apps/mull-api/src/app/auth/auth.guard.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.ts
@@ -1,0 +1,16 @@
+import { GqlContext, IAuthToken } from '@mull/types';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import jwt from 'jsonwebtoken';
+import { environment } from '../../environments/environment';
+
+export const AuthenticatedUser = createParamDecorator((_, context: ExecutionContext): number => {
+  const ctx = GqlExecutionContext.create(context);
+  const accessToken = ctx.getContext<GqlContext>().req.headers.authorization.split(' ')[1];
+  try {
+    const { id } = jwt.verify(accessToken, environment.jwt.accessSecret) as IAuthToken;
+    return id;
+  } catch (err) {
+    throw new UnauthorizedException('Unauthorized');
+  }
+});

--- a/apps/mull-api/src/app/auth/auth.guard.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.ts
@@ -13,8 +13,8 @@ import { environment } from '../../environments/environment';
 @Injectable()
 export class AuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
-    const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
     try {
+      const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
       return !!jwt.verify(accessToken, environment.jwt.accessSecret);
     } catch (err) {
       throw new UnauthorizedException('Unauthorized');
@@ -23,8 +23,8 @@ export class AuthGuard implements CanActivate {
 }
 
 export const AuthenticatedUser = createParamDecorator((_, context: ExecutionContext): number => {
-  const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
   try {
+    const accessToken = context.switchToHttp().getNext().req.headers.authorization.split(' ')[1];
     const { id } = jwt.verify(accessToken, environment.jwt.accessSecret) as IAuthToken;
     return id;
   } catch (err) {

--- a/apps/mull-api/src/app/auth/auth.guard.ts
+++ b/apps/mull-api/src/app/auth/auth.guard.ts
@@ -1,8 +1,28 @@
 import { GqlContext, IAuthToken } from '@mull/types';
-import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  CanActivate,
+  createParamDecorator,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import jwt from 'jsonwebtoken';
+import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const ctx = GqlExecutionContext.create(context);
+    const accessToken = ctx.getContext<GqlContext>().req.headers.authorization.split(' ')[1];
+    try {
+      return !!jwt.verify(accessToken, environment.jwt.accessSecret);
+    } catch (err) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+  }
+}
 
 export const AuthenticatedUser = createParamDecorator((_, context: ExecutionContext): number => {
   const ctx = GqlExecutionContext.create(context);

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -7,7 +7,10 @@ import { EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 
 const mockEventService = () => ({
-  createEvent: jest.fn((mockEventData: CreateEventInput) => ({ ...mockEventData })),
+  createEvent: jest.fn((hostId: number, mockEventData: CreateEventInput) => ({
+    ...mockEventData,
+    hostId: { id: hostId },
+  })),
   getEvent: jest.fn((id: number) => mockAllEvents.find((event) => event.id === id)),
   getAllEvents: jest.fn(() => mockAllEvents),
   updateEvent: jest.fn((mockEventData: UpdateEventInput) => ({ ...mockEventData })),
@@ -58,8 +61,8 @@ describe('UserResolver', () => {
   });
 
   it('should create event', async () => {
-    const returnedEvent = await resolver.createEvent(mockPartialEvent as CreateEventInput);
-    expect(returnedEvent).toEqual(mockPartialEvent);
+    const returnedEvent = await resolver.createEvent(5, mockPartialEvent as CreateEventInput);
+    expect(returnedEvent).toEqual({ ...mockPartialEvent, hostId: { id: 5 } });
   });
 
   it('should fetch all events', async () => {

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -50,9 +50,8 @@ export class EventResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
-  @UseGuards(AuthGuard)
-  async createEvent(@Args('event') event: CreateEventInput) {
-    return this.eventService.createEvent(event);
+  async createEvent(@AuthenticatedUser() hostId: number, @Args('event') event: CreateEventInput) {
+    return this.eventService.createEvent(hostId, event);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -1,4 +1,6 @@
+import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { AuthenticatedUser, AuthGuard } from '../auth/auth.guard';
 import { Event, Media } from '../entities';
 import { EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
@@ -8,60 +10,59 @@ export class EventResolver {
   constructor(private readonly eventService: EventService) {}
 
   @Query(/* istanbul ignore next */ () => [Event])
+  @UseGuards(AuthGuard)
   async events() {
     return this.eventService.getAllEvents();
   }
 
   @Query(/* istanbul ignore next */ () => Event)
+  @UseGuards(AuthGuard)
   async event(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
     return this.eventService.getEvent(id);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async hostEvents(@Args('hostId', { type: /* istanbul ignore next */ () => Int }) hostId: number) {
+  async hostEvents(@AuthenticatedUser() hostId: number) {
     return this.eventService.getEventsHostedByUser(hostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async coHostEvents(
-    @Args('coHostId', { type: /* istanbul ignore next */ () => Int }) coHostId: number
-  ) {
+  async coHostEvents(@AuthenticatedUser() coHostId: number) {
     return this.eventService.getEventsCoHostedByUser(coHostId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async participantEvents(
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
-  ) {
+  async participantEvents(@AuthenticatedUser() userId: number) {
     return this.eventService.getEventsAttendedByUser(userId);
   }
 
   @Query(/* istanbul ignore next */ () => Boolean)
   async isParticipant(
     @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+    @AuthenticatedUser() userId: number
   ) {
     return this.eventService.isUserAttendingEvent(eventId, userId);
   }
 
   @Query(/* istanbul ignore next */ () => [Event])
-  async discoverEvents(
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
-  ) {
+  async discoverEvents(@AuthenticatedUser() userId: number) {
     return this.eventService.getEventsRecommendedToUser(userId);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
+  @UseGuards(AuthGuard)
   async createEvent(@Args('event') event: CreateEventInput) {
     return this.eventService.createEvent(event);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
+  @UseGuards(AuthGuard)
   async updateEvent(@Args('event') event: UpdateEventInput) {
     return this.eventService.updateEvent(event);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)
+  @UseGuards(AuthGuard)
   async deleteEvent(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
     return this.eventService.deleteEvent(id);
   }
@@ -69,7 +70,7 @@ export class EventResolver {
   @Mutation(() => Boolean)
   async joinEvent(
     @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+    @AuthenticatedUser() userId: number
   ) {
     this.eventService.addEventParticipant(eventId, userId);
     return true;
@@ -78,7 +79,7 @@ export class EventResolver {
   @Mutation(() => Boolean)
   async leaveEvent(
     @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number,
-    @Args('userId', { type: /* istanbul ignore next */ () => Int }) userId: number
+    @AuthenticatedUser() userId: number
   ) {
     this.eventService.removeEventParticipant(eventId, userId);
     return true;

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -55,8 +55,9 @@ describe('EventService', () => {
   });
 
   it('should create the event', async () => {
-    const returnedEvent = await service.createEvent(mockPartialEvent as CreateEventInput);
-    expect(returnedEvent).toEqual(mockPartialEvent);
+    const hostId = 5;
+    const returnedEvent = await service.createEvent(hostId, mockPartialEvent as CreateEventInput);
+    expect(returnedEvent).toEqual({ ...mockPartialEvent, host: { id: hostId } });
   });
 
   it('should fetch all events', async () => {

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -109,8 +109,8 @@ export class EventService {
       .getMany();
   }
 
-  async createEvent(input: CreateEventInput): Promise<Event> {
-    return await this.eventRepository.save(input);
+  async createEvent(hostId: number, input: CreateEventInput): Promise<Event> {
+    return await this.eventRepository.save({ ...input, host: { id: hostId } });
   }
 
   async updateEvent(input: UpdateEventInput): Promise<Event> {

--- a/apps/mull-api/src/app/event/inputs/event.input.ts
+++ b/apps/mull-api/src/app/event/inputs/event.input.ts
@@ -7,7 +7,7 @@ import { MediaInput } from '../../media/inputs/media.input';
 @InputType()
 export class CreateEventInput {
   @Field()
-  title?: string;
+  title: string;
 
   @Field()
   startDate: Date;

--- a/apps/mull-api/src/app/event/inputs/event.input.ts
+++ b/apps/mull-api/src/app/event/inputs/event.input.ts
@@ -3,12 +3,11 @@ import { Field, InputType, Int } from '@nestjs/graphql';
 import { Event, Location, Media } from '../../entities';
 import { LocationInput } from '../../location/inputs/location.input';
 import { MediaInput } from '../../media/inputs/media.input';
-import { UserInput } from '../../user/inputs/user.input';
 
 @InputType()
 export class CreateEventInput {
   @Field()
-  title: string;
+  title?: string;
 
   @Field()
   startDate: Date;
@@ -24,9 +23,6 @@ export class CreateEventInput {
 
   @Field(/* istanbul ignore next */ () => MediaInput)
   image: Media;
-
-  @Field(/* istanbul ignore next */ () => UserInput)
-  host: UserInput;
 
   @Field(/* istanbul ignore next*/ () => LocationInput)
   location: Location;

--- a/apps/mull-api/src/app/location/location.resolver.ts
+++ b/apps/mull-api/src/app/location/location.resolver.ts
@@ -1,4 +1,6 @@
+import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { AuthGuard } from '../auth/auth.guard';
 import { Location } from '../entities';
 import { LocationInput } from './inputs/location.input';
 import { LocationService } from './location.service';
@@ -8,11 +10,13 @@ export class LocationResolver {
   constructor(private readonly locationService: LocationService) {}
 
   @Query(/* istanbul ignore next */ () => Location)
+  @UseGuards(AuthGuard)
   async location(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
     return this.locationService.getLocation(id);
   }
 
   @Mutation(/* istanbul ignore next */ () => Location)
+  @UseGuards(AuthGuard)
   async createLocation(@Args('location') location: LocationInput) {
     return this.locationService.createLocation(location);
   }

--- a/apps/mull-api/src/app/media/media.resolver.ts
+++ b/apps/mull-api/src/app/media/media.resolver.ts
@@ -1,6 +1,8 @@
+import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { GraphQLUpload } from 'apollo-server-express';
 import { FileUpload } from 'graphql-upload';
+import { AuthGuard } from '../auth/auth.guard';
 import { Media } from '../entities';
 import { MediaService } from './media.service';
 
@@ -9,6 +11,7 @@ export class MediaResolver {
   constructor(private readonly mediaService: MediaService) {}
 
   @Mutation(/* istanbul ignore next */ () => Media)
+  @UseGuards(AuthGuard)
   async uploadFile(
     @Args('file', { type: /* istanbul ignore next */ () => GraphQLUpload })
     file: FileUpload

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -1,4 +1,6 @@
-import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { AuthenticatedUser, AuthGuard } from '../auth/auth.guard';
 import { User } from '../entities';
 import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
 import { UserService } from './user.service';
@@ -8,12 +10,13 @@ export class UserResolver {
   constructor(private readonly userService: UserService) {}
 
   @Query(/* istanbul ignore next */ () => [User])
+  @UseGuards(AuthGuard)
   async users() {
     return this.userService.getAllUsers();
   }
 
   @Query(/* istanbul ignore next */ () => User)
-  async user(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
+  async user(@AuthenticatedUser() id: number) {
     return this.userService.getUser(id);
   }
 
@@ -24,17 +27,19 @@ export class UserResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
+  @UseGuards(AuthGuard)
   async createUser(@Args('user') user: CreateUserInput) {
     return this.userService.createUser(user);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
+  @UseGuards(AuthGuard)
   async updateUser(@Args('user') user: UpdateUserInput) {
     return this.userService.updateUser(user);
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  async deleteUser(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
+  async deleteUser(@AuthenticatedUser() id: number) {
     return this.userService.deleteUser(id);
   }
 }

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -27,7 +27,6 @@ export class UserResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => User)
-  @UseGuards(AuthGuard)
   async createUser(@Args('user') user: CreateUserInput) {
     return this.userService.createUser(user);
   }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -75,9 +75,9 @@ type Mutation {
   createLocation(location: LocationInput!): Location!
   createUser(user: CreateUserInput!): User!
   deleteEvent(id: Int!): Event!
-  deleteUser(id: Int!): User!
-  joinEvent(eventId: Int!, userId: Int!): Boolean!
-  leaveEvent(eventId: Int!, userId: Int!): Boolean!
+  deleteUser: User!
+  joinEvent(eventId: Int!): Boolean!
+  leaveEvent(eventId: Int!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
   updateEvent(event: UpdateEventInput!): Event!
   updateUser(user: UpdateUserInput!): User!
@@ -96,15 +96,15 @@ input PointInput {
 }
 
 type Query {
-  coHostEvents(coHostId: Int!): [Event!]!
-  discoverEvents(userId: Int!): [Event!]!
+  coHostEvents: [Event!]!
+  discoverEvents: [Event!]!
   event(id: Int!): Event!
   events: [Event!]!
-  hostEvents(hostId: Int!): [Event!]!
-  isParticipant(eventId: Int!, userId: Int!): Boolean!
+  hostEvents: [Event!]!
+  isParticipant(eventId: Int!): Boolean!
   location(id: Int!): Location!
-  participantEvents(userId: Int!): [Event!]!
-  user(id: Int!): User!
+  participantEvents: [Event!]!
+  user: User!
   users: [User!]!
 }
 

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -5,7 +5,6 @@
 input CreateEventInput {
   description: String!
   endDate: DateTime!
-  host: UserInput!
   image: MediaInput!
   location: LocationInput!
   restriction: Int!
@@ -145,8 +144,4 @@ type User {
   password: String
   registrationMethod: RegistrationMethod!
   timezone: String!
-}
-
-input UserInput {
-  id: Int!
 }

--- a/apps/mull-ui-e2e/src/support/commands.ts
+++ b/apps/mull-ui-e2e/src/support/commands.ts
@@ -8,7 +8,7 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-const jwt = require('jsonwebtoken');
+import jwt from 'jsonwebtoken';
 
 declare namespace Cypress {
   interface Chainable<Subject> {

--- a/apps/mull-ui-e2e/src/support/commands.ts
+++ b/apps/mull-ui-e2e/src/support/commands.ts
@@ -8,19 +8,20 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
+const jwt = require('jsonwebtoken');
+
 declare namespace Cypress {
   interface Chainable<Subject> {
-    mockRefreshRequest(): void;
+    mockRefreshRequest(userId?): void;
   }
 }
 //
 // -- This is a parent command --
-Cypress.Commands.add('mockRefreshRequest', () => {
+Cypress.Commands.add('mockRefreshRequest', (userId = 1) => {
   cy.intercept('POST', 'http://localhost:3333/api/auth/refresh', {
     statusCode: 201,
     body: {
-      accessToken:
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjEyMDQ3NjA0LCJleHAiOjE2MTIwNDg1MDR9.Wmb_xkPVM_qLBjsG_uVe9yMvYsHj7ECoitc7yW4LyNE',
+      accessToken: jwt.sign({ id: userId }, Cypress.env('ACCESS_TOKEN_SECRET')),
       ok: true,
     },
   });

--- a/apps/mull-ui-e2e/src/support/commands.ts
+++ b/apps/mull-ui-e2e/src/support/commands.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars, @typescript-eslint/no-var-requires */
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -8,7 +8,7 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-import jwt from 'jsonwebtoken';
+const jwt = require('jsonwebtoken');
 
 declare namespace Cypress {
   interface Chainable<Subject> {

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -1,11 +1,10 @@
 import { faCheck, faShareAlt, faSignInAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { dummyProfilePictures } from '../../../constants'; // TODO query the participants profile pictures
 import { useJoinEventMutation, useLeaveEventMutation } from '../../../generated/graphql';
 import { formatDate, mediaUrl } from '../../../utilities';
-import UserContext from '../../context/user.context';
 import EventMembers from '../event-members/event-members';
 import './event-card.scss';
 
@@ -20,8 +19,6 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
   const { day, month, time } = formatDate(new Date(event.startDate));
 
   const [joined, setJoined] = useState<boolean>(isJoined);
-
-  const { userId } = useContext(UserContext);
 
   const [joinEvent] = useJoinEventMutation();
   const [leaveEvent] = useLeaveEventMutation();
@@ -42,9 +39,9 @@ export const EventCard = ({ event, style = {}, onClick, isJoined = false }: Even
           e.stopPropagation();
           setJoined(!joined);
           if (joined === false) {
-            joinEvent({ variables: { eventId: event.id, userId } });
+            joinEvent({ variables: { eventId: event.id } });
           } else {
-            leaveEvent({ variables: { eventId: event.id, userId } });
+            leaveEvent({ variables: { eventId: event.id } });
           }
         }}
         className={`event-card-join ${joined ? 'joined' : ''}`}

--- a/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/components/event-page-info/event-page-info.tsx
@@ -9,9 +9,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { EventRestrictionMap, ISerializedEvent } from '@mull/types';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useJoinEventMutation, useLeaveEventMutation } from '../../../generated/graphql';
-import UserContext from '../../context/user.context';
 import MullButton from '../mull-button/mull-button';
 import { ExpandableText } from './../expandable-text/expandable-text';
 import './event-page-info.scss';
@@ -38,16 +37,15 @@ export const EventPageInfo = ({
   const [joinEvent] = useJoinEventMutation();
   const [leaveEvent] = useLeaveEventMutation();
 
-  const { userId } = useContext(UserContext);
   const [joined, setJoined] = useState<boolean>(isJoined);
 
   const handleJoinEventButton = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
     e.stopPropagation();
     setJoined(!joined);
     if (joined) {
-      leaveEvent({ variables: { eventId: event.id, userId } });
+      leaveEvent({ variables: { eventId: event.id } });
     } else {
-      joinEvent({ variables: { eventId: event.id, userId } });
+      joinEvent({ variables: { eventId: event.id } });
     }
   };
 

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -4,7 +4,7 @@ import { EventRestriction, EventRestrictionMap, ICreateEventForm } from '@mull/t
 import { FormikTouched, FormikValues, setNestedObjectValues, useFormik } from 'formik';
 import { History } from 'history';
 import { cloneDeep, isEmpty } from 'lodash';
-import React, { ChangeEvent, useContext, useState } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import { toast } from 'react-toastify';
 import * as Yup from 'yup';
 import { DAY_IN_MILLISECONDS, ROUTES } from '../../../constants';
@@ -13,7 +13,6 @@ import {
   useCreateEventMutation,
   useUploadFileMutation,
 } from '../../../generated/graphql';
-import UserContext from '../../context/user.context';
 import { useToast } from '../../hooks/useToast';
 import {
   CustomFileUpload,
@@ -45,7 +44,6 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
   const [isInReview, setIsInReview] = useState<boolean>(false); // Show either form or review page
   const [payload, setPayload] = useState<Partial<CreateEventInput>>(null);
   const { notifyToast, updateToast } = useToast();
-  const { userId } = useContext(UserContext);
   /**
    * Handles image file uploads
    * @param {ChangeEvent<HTMLInputElement>} event
@@ -161,9 +159,6 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
         restriction: formik.values.activeRestriction,
         location: formik.values.location,
         image: null,
-        host: {
-          id: userId,
-        },
       });
       setIsInReview(true);
     } else {

--- a/apps/mull-ui/src/app/pages/event-page/event-page.spec.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.spec.tsx
@@ -65,7 +65,7 @@ describe('EventPage', () => {
       {
         request: {
           query: EventPageDocument,
-          variables: { userId: 1, eventId: 1 },
+          variables: { eventId: 1 },
         },
         result: {
           data: {

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -1,9 +1,8 @@
 import { cloneDeep } from 'lodash';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { CreateEventInput, useEventPageQuery, useUserQuery } from '../../../generated/graphql';
 import { EventPageHeader, EventPageInfo } from '../../components';
-import UserContext from '../../context/user.context';
 import './event-page.scss';
 
 export interface EventPageProps {
@@ -30,17 +29,14 @@ export const EventPage = ({
   const { id } = useParams<{ id: string }>();
   const eventId = parseInt(id);
 
-  const { userId } = useContext(UserContext);
-
   let event = cloneDeep(reviewEvent);
 
   const { loading: loadingEvent, error: errorEvent, data: dataEvent } = useEventPageQuery({
-    variables: { eventId, userId },
+    variables: { eventId },
     skip: !!reviewEvent,
   });
 
   const { loading: loadingUser, error: errorUser, data: dataUser } = useUserQuery({
-    variables: { userId },
     skip: !reviewEvent,
   });
 

--- a/apps/mull-ui/src/app/pages/event-page/event-page.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page.tsx
@@ -1,3 +1,4 @@
+import { ISerializedEvent } from '@mull/types';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -29,7 +30,7 @@ export const EventPage = ({
   const { id } = useParams<{ id: string }>();
   const eventId = parseInt(id);
 
-  let event = cloneDeep(reviewEvent);
+  let event = cloneDeep(reviewEvent) as ISerializedEvent;
 
   const { loading: loadingEvent, error: errorEvent, data: dataEvent } = useEventPageQuery({
     variables: { eventId },

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.spec.tsx
@@ -36,7 +36,6 @@ describe('discoverPage', () => {
         {
           request: {
             query: DiscoverEventsDocument,
-            variables: { userId: 1 },
           },
           result: {
             data: {

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -1,16 +1,11 @@
 import { ISerializedEvent } from '@mull/types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDiscoverEventsQuery } from '../../../../generated/graphql';
 import { EventCard } from '../../../components';
-import UserContext from '../../../context/user.context';
 import '../home-discover.scss';
 
 export const DiscoverPage = ({ history }) => {
-  const { userId } = useContext(UserContext);
-
-  const { data } = useDiscoverEventsQuery({
-    variables: { userId },
-  });
+  const { data } = useDiscoverEventsQuery({});
 
   if (data) {
     const events = (data.discoverEvents as unknown) as Partial<ISerializedEvent>[];

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.spec.tsx
@@ -36,7 +36,6 @@ describe('myEventsPage', () => {
         {
           request: {
             query: OwnedEventsDocument,
-            variables: { userId: 1 },
           },
           result: {
             data: {

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -1,16 +1,11 @@
 import { ISerializedEvent } from '@mull/types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useOwnedEventsQuery } from '../../../../generated/graphql';
 import { EventCard } from '../../../components';
-import UserContext from '../../../context/user.context';
 import '../home-discover.scss';
 
 export const MyEventsPage = ({ history }) => {
-  const { userId } = useContext(UserContext);
-
-  const { data } = useOwnedEventsQuery({
-    variables: { userId },
-  });
+  const { data } = useOwnedEventsQuery({});
 
   if (data) {
     const events = (data.coHostEvents.concat(data.hostEvents) as unknown) as Partial<

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.spec.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.spec.tsx
@@ -36,7 +36,6 @@ describe('UpcomingPage', () => {
         {
           request: {
             query: ParticipantEventsDocument,
-            variables: { userId: 1 },
           },
           result: {
             data: {

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -1,15 +1,10 @@
 import { ISerializedEvent } from '@mull/types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useParticipantEventsQuery } from '../../../../generated/graphql';
 import { EventCard } from '../../../components';
-import UserContext from '../../../context/user.context';
 
 export const UpcomingPage = ({ history }) => {
-  const { userId } = useContext(UserContext);
-
-  const { data } = useParticipantEventsQuery({
-    variables: { userId },
-  });
+  const { data } = useParticipantEventsQuery({});
 
   if (data) {
     const events = (data.participantEvents as unknown) as Partial<ISerializedEvent>[];

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
@@ -53,9 +53,8 @@ const EditProfile = () => {
 
   return (
     <div className="page-container">
+      <MullBackButton>Profile</MullBackButton>
       <form className="edit-profile-container" onSubmit={formik.handleSubmit}>
-        <MullBackButton>Profile</MullBackButton>
-
         <p className="edit-header">Edit Profile</p>
 
         <CustomFileUpload

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -20,7 +20,6 @@ export type Scalars = {
 export type CreateEventInput = {
   description: Scalars['String'];
   endDate: Scalars['DateTime'];
-  host: UserInput;
   image: MediaInput;
   location: LocationInput;
   restriction: Scalars['Int'];
@@ -227,10 +226,6 @@ export type User = {
   password?: Maybe<Scalars['String']>;
   registrationMethod: RegistrationMethod;
   timezone: Scalars['String'];
-};
-
-export type UserInput = {
-  id: Scalars['Int'];
 };
 
 export type CreateEventMutationVariables = Exact<{

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -121,20 +121,13 @@ export type MutationDeleteEventArgs = {
 };
 
 
-export type MutationDeleteUserArgs = {
-  id: Scalars['Int'];
-};
-
-
 export type MutationJoinEventArgs = {
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 };
 
 
 export type MutationLeaveEventArgs = {
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 };
 
 
@@ -184,43 +177,17 @@ export type Query = {
 };
 
 
-export type QueryCoHostEventsArgs = {
-  coHostId: Scalars['Int'];
-};
-
-
-export type QueryDiscoverEventsArgs = {
-  userId: Scalars['Int'];
-};
-
-
 export type QueryEventArgs = {
   id: Scalars['Int'];
 };
 
 
-export type QueryHostEventsArgs = {
-  hostId: Scalars['Int'];
-};
-
-
 export type QueryIsParticipantArgs = {
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 };
 
 
 export type QueryLocationArgs = {
-  id: Scalars['Int'];
-};
-
-
-export type QueryParticipantEventsArgs = {
-  userId: Scalars['Int'];
-};
-
-
-export type QueryUserArgs = {
   id: Scalars['Int'];
 };
 
@@ -320,7 +287,6 @@ export type LoginMutation = (
 
 export type JoinEventMutationVariables = Exact<{
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 }>;
 
 
@@ -331,7 +297,6 @@ export type JoinEventMutation = (
 
 export type LeaveEventMutationVariables = Exact<{
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 }>;
 
 
@@ -367,9 +332,7 @@ export type EventCardContentFragment = (
   )> }
 );
 
-export type DiscoverEventsQueryVariables = Exact<{
-  userId: Scalars['Int'];
-}>;
+export type DiscoverEventsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type DiscoverEventsQuery = (
@@ -380,9 +343,7 @@ export type DiscoverEventsQuery = (
   )> }
 );
 
-export type OwnedEventsQueryVariables = Exact<{
-  userId: Scalars['Int'];
-}>;
+export type OwnedEventsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type OwnedEventsQuery = (
@@ -396,9 +357,7 @@ export type OwnedEventsQuery = (
   )> }
 );
 
-export type ParticipantEventsQueryVariables = Exact<{
-  userId: Scalars['Int'];
-}>;
+export type ParticipantEventsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type ParticipantEventsQuery = (
@@ -411,7 +370,6 @@ export type ParticipantEventsQuery = (
 
 export type EventPageQueryVariables = Exact<{
   eventId: Scalars['Int'];
-  userId: Scalars['Int'];
 }>;
 
 
@@ -424,9 +382,7 @@ export type EventPageQuery = (
   ) }
 );
 
-export type UserQueryVariables = Exact<{
-  userId: Scalars['Int'];
-}>;
+export type UserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type UserQuery = (
@@ -603,8 +559,8 @@ export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const JoinEventDocument = gql`
-    mutation JoinEvent($eventId: Int!, $userId: Int!) {
-  joinEvent(eventId: $eventId, userId: $userId)
+    mutation JoinEvent($eventId: Int!) {
+  joinEvent(eventId: $eventId)
 }
     `;
 export type JoinEventMutationFn = Apollo.MutationFunction<JoinEventMutation, JoinEventMutationVariables>;
@@ -623,7 +579,6 @@ export type JoinEventMutationFn = Apollo.MutationFunction<JoinEventMutation, Joi
  * const [joinEventMutation, { data, loading, error }] = useJoinEventMutation({
  *   variables: {
  *      eventId: // value for 'eventId'
- *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -634,8 +589,8 @@ export type JoinEventMutationHookResult = ReturnType<typeof useJoinEventMutation
 export type JoinEventMutationResult = Apollo.MutationResult<JoinEventMutation>;
 export type JoinEventMutationOptions = Apollo.BaseMutationOptions<JoinEventMutation, JoinEventMutationVariables>;
 export const LeaveEventDocument = gql`
-    mutation LeaveEvent($eventId: Int!, $userId: Int!) {
-  leaveEvent(eventId: $eventId, userId: $userId)
+    mutation LeaveEvent($eventId: Int!) {
+  leaveEvent(eventId: $eventId)
 }
     `;
 export type LeaveEventMutationFn = Apollo.MutationFunction<LeaveEventMutation, LeaveEventMutationVariables>;
@@ -654,7 +609,6 @@ export type LeaveEventMutationFn = Apollo.MutationFunction<LeaveEventMutation, L
  * const [leaveEventMutation, { data, loading, error }] = useLeaveEventMutation({
  *   variables: {
  *      eventId: // value for 'eventId'
- *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -665,8 +619,8 @@ export type LeaveEventMutationHookResult = ReturnType<typeof useLeaveEventMutati
 export type LeaveEventMutationResult = Apollo.MutationResult<LeaveEventMutation>;
 export type LeaveEventMutationOptions = Apollo.BaseMutationOptions<LeaveEventMutation, LeaveEventMutationVariables>;
 export const DiscoverEventsDocument = gql`
-    query DiscoverEvents($userId: Int!) {
-  discoverEvents(userId: $userId) {
+    query DiscoverEvents {
+  discoverEvents {
     ...EventCardContent
   }
 }
@@ -684,11 +638,10 @@ export const DiscoverEventsDocument = gql`
  * @example
  * const { data, loading, error } = useDiscoverEventsQuery({
  *   variables: {
- *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useDiscoverEventsQuery(baseOptions: Apollo.QueryHookOptions<DiscoverEventsQuery, DiscoverEventsQueryVariables>) {
+export function useDiscoverEventsQuery(baseOptions?: Apollo.QueryHookOptions<DiscoverEventsQuery, DiscoverEventsQueryVariables>) {
         return Apollo.useQuery<DiscoverEventsQuery, DiscoverEventsQueryVariables>(DiscoverEventsDocument, baseOptions);
       }
 export function useDiscoverEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DiscoverEventsQuery, DiscoverEventsQueryVariables>) {
@@ -698,11 +651,11 @@ export type DiscoverEventsQueryHookResult = ReturnType<typeof useDiscoverEventsQ
 export type DiscoverEventsLazyQueryHookResult = ReturnType<typeof useDiscoverEventsLazyQuery>;
 export type DiscoverEventsQueryResult = Apollo.QueryResult<DiscoverEventsQuery, DiscoverEventsQueryVariables>;
 export const OwnedEventsDocument = gql`
-    query OwnedEvents($userId: Int!) {
-  coHostEvents(coHostId: $userId) {
+    query OwnedEvents {
+  coHostEvents {
     ...EventCardContent
   }
-  hostEvents(hostId: $userId) {
+  hostEvents {
     ...EventCardContent
   }
 }
@@ -720,11 +673,10 @@ export const OwnedEventsDocument = gql`
  * @example
  * const { data, loading, error } = useOwnedEventsQuery({
  *   variables: {
- *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useOwnedEventsQuery(baseOptions: Apollo.QueryHookOptions<OwnedEventsQuery, OwnedEventsQueryVariables>) {
+export function useOwnedEventsQuery(baseOptions?: Apollo.QueryHookOptions<OwnedEventsQuery, OwnedEventsQueryVariables>) {
         return Apollo.useQuery<OwnedEventsQuery, OwnedEventsQueryVariables>(OwnedEventsDocument, baseOptions);
       }
 export function useOwnedEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OwnedEventsQuery, OwnedEventsQueryVariables>) {
@@ -734,8 +686,8 @@ export type OwnedEventsQueryHookResult = ReturnType<typeof useOwnedEventsQuery>;
 export type OwnedEventsLazyQueryHookResult = ReturnType<typeof useOwnedEventsLazyQuery>;
 export type OwnedEventsQueryResult = Apollo.QueryResult<OwnedEventsQuery, OwnedEventsQueryVariables>;
 export const ParticipantEventsDocument = gql`
-    query ParticipantEvents($userId: Int!) {
-  participantEvents(userId: $userId) {
+    query ParticipantEvents {
+  participantEvents {
     ...EventCardContent
   }
 }
@@ -753,11 +705,10 @@ export const ParticipantEventsDocument = gql`
  * @example
  * const { data, loading, error } = useParticipantEventsQuery({
  *   variables: {
- *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useParticipantEventsQuery(baseOptions: Apollo.QueryHookOptions<ParticipantEventsQuery, ParticipantEventsQueryVariables>) {
+export function useParticipantEventsQuery(baseOptions?: Apollo.QueryHookOptions<ParticipantEventsQuery, ParticipantEventsQueryVariables>) {
         return Apollo.useQuery<ParticipantEventsQuery, ParticipantEventsQueryVariables>(ParticipantEventsDocument, baseOptions);
       }
 export function useParticipantEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ParticipantEventsQuery, ParticipantEventsQueryVariables>) {
@@ -767,8 +718,8 @@ export type ParticipantEventsQueryHookResult = ReturnType<typeof useParticipantE
 export type ParticipantEventsLazyQueryHookResult = ReturnType<typeof useParticipantEventsLazyQuery>;
 export type ParticipantEventsQueryResult = Apollo.QueryResult<ParticipantEventsQuery, ParticipantEventsQueryVariables>;
 export const EventPageDocument = gql`
-    query EventPage($eventId: Int!, $userId: Int!) {
-  isParticipant(eventId: $eventId, userId: $userId)
+    query EventPage($eventId: Int!) {
+  isParticipant(eventId: $eventId)
   event(id: $eventId) {
     ...EventPageContent
   }
@@ -788,7 +739,6 @@ export const EventPageDocument = gql`
  * const { data, loading, error } = useEventPageQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
- *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -802,8 +752,8 @@ export type EventPageQueryHookResult = ReturnType<typeof useEventPageQuery>;
 export type EventPageLazyQueryHookResult = ReturnType<typeof useEventPageLazyQuery>;
 export type EventPageQueryResult = Apollo.QueryResult<EventPageQuery, EventPageQueryVariables>;
 export const UserDocument = gql`
-    query User($userId: Int!) {
-  user(id: $userId) {
+    query User {
+  user {
     id
     name
   }
@@ -822,11 +772,10 @@ export const UserDocument = gql`
  * @example
  * const { data, loading, error } = useUserQuery({
  *   variables: {
- *      userId: // value for 'userId'
  *   },
  * });
  */
-export function useUserQuery(baseOptions: Apollo.QueryHookOptions<UserQuery, UserQueryVariables>) {
+export function useUserQuery(baseOptions?: Apollo.QueryHookOptions<UserQuery, UserQueryVariables>) {
         return Apollo.useQuery<UserQuery, UserQueryVariables>(UserDocument, baseOptions);
       }
 export function useUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserQuery, UserQueryVariables>) {

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -28,11 +28,11 @@ mutation Login($loginInput: LoginInput!) {
 }
 
 # User joins an event
-mutation JoinEvent($eventId: Int!, $userId: Int!) {
-  joinEvent(eventId: $eventId, userId: $userId)
+mutation JoinEvent($eventId: Int!) {
+  joinEvent(eventId: $eventId)
 }
 
 # User leaves an event
-mutation LeaveEvent($eventId: Int!, $userId: Int!) {
-  leaveEvent(eventId: $eventId, userId: $userId)
+mutation LeaveEvent($eventId: Int!) {
+  leaveEvent(eventId: $eventId)
 }

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -32,40 +32,40 @@ fragment EventCardContent on Event {
   }
 }
 
-query DiscoverEvents($userId: Int!) {
-  discoverEvents(userId: $userId) {
+query DiscoverEvents {
+  discoverEvents {
     ...EventCardContent
   }
 }
 
 # Gets all related events to a user
-query OwnedEvents($userId: Int!) {
-  coHostEvents(coHostId: $userId) {
+query OwnedEvents {
+  coHostEvents {
     ...EventCardContent
   }
-  hostEvents(hostId: $userId) {
+  hostEvents {
     ...EventCardContent
   }
 }
 
 # Get all the events that a user is participating in
-query ParticipantEvents($userId: Int!) {
-  participantEvents(userId: $userId) {
+query ParticipantEvents {
+  participantEvents {
     ...EventCardContent
   }
 }
 
 # Find events by Id and finds participating events of user
-query EventPage($eventId: Int!, $userId: Int!) {
-  isParticipant(eventId: $eventId, userId: $userId)
+query EventPage($eventId: Int!) {
+  isParticipant(eventId: $eventId)
 
   event(id: $eventId) {
     ...EventPageContent
   }
 }
 
-query User($userId: Int!) {
-  user(id: $userId) {
+query User {
+  user {
     id
     name
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2070,6 +2070,12 @@
         "prop-types": "^15.7.2"
       }
     },
+    "@golevelup/nestjs-testing": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz",
+      "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ==",
+      "dev": true
+    },
     "@graphql-codegen/cli": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-1.20.0.tgz",
@@ -10493,22 +10499,14 @@
           }
         },
         "graphql-upload": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-          "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+          "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
           "requires": {
             "busboy": "^0.3.1",
-            "fs-capacitor": "^6.1.0",
+            "fs-capacitor": "^2.0.4",
             "http-errors": "^1.7.3",
-            "isobject": "^4.0.0",
             "object-path": "^0.11.4"
-          },
-          "dependencies": {
-            "fs-capacitor": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
-              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
-            }
           }
         },
         "http-errors": {
@@ -10522,11 +10520,6 @@
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -10636,21 +10629,37 @@
             "ws": "^6.0.0"
           },
           "dependencies": {
-            "fs-capacitor": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
-              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
-            },
             "graphql-upload": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-              "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+              "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
               "requires": {
                 "busboy": "^0.3.1",
-                "fs-capacitor": "^6.1.0",
+                "fs-capacitor": "^2.0.4",
                 "http-errors": "^1.7.3",
-                "isobject": "^4.0.0",
                 "object-path": "^0.11.4"
+              },
+              "dependencies": {
+                "busboy": {
+                  "version": "0.3.1",
+                  "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+                  "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+                  "requires": {
+                    "dicer": "0.3.0"
+                  }
+                },
+                "http-errors": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+                  "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+                  "requires": {
+                    "depd": "~1.1.2",
+                    "inherits": "2.0.4",
+                    "setprototypeof": "1.2.0",
+                    "statuses": ">= 1.5.0 < 2",
+                    "toidentifier": "1.0.0"
+                  }
+                }
               }
             }
           }
@@ -10671,14 +10680,6 @@
             "apollo-reporting-protobuf": "^0.6.0",
             "apollo-server-caching": "^0.5.2",
             "apollo-server-env": "^2.4.5"
-          }
-        },
-        "busboy": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-          "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-          "requires": {
-            "dicer": "0.3.0"
           }
         },
         "dicer": {
@@ -10718,28 +10719,8 @@
           "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
           "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
           "requires": {
-            "busboy": "^0.3.1",
-            "http-errors": "^1.7.3",
-            "isobject": "^4.0.0",
             "object-path": "^0.11.4"
           }
-        },
-        "http-errors": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         },
         "lru-cache": {
           "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10499,14 +10499,22 @@
           }
         },
         "graphql-upload": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
-          "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
+          "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
           "requires": {
             "busboy": "^0.3.1",
-            "fs-capacitor": "^2.0.4",
+            "fs-capacitor": "^6.1.0",
             "http-errors": "^1.7.3",
+            "isobject": "^4.0.0",
             "object-path": "^0.11.4"
+          },
+          "dependencies": {
+            "fs-capacitor": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
+              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
+            }
           }
         },
         "http-errors": {
@@ -10520,6 +10528,11 @@
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -10629,37 +10642,21 @@
             "ws": "^6.0.0"
           },
           "dependencies": {
+            "fs-capacitor": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
+              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
+            },
             "graphql-upload": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
-              "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
+              "version": "11.0.0",
+              "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
+              "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
               "requires": {
                 "busboy": "^0.3.1",
-                "fs-capacitor": "^2.0.4",
+                "fs-capacitor": "^6.1.0",
                 "http-errors": "^1.7.3",
+                "isobject": "^4.0.0",
                 "object-path": "^0.11.4"
-              },
-              "dependencies": {
-                "busboy": {
-                  "version": "0.3.1",
-                  "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-                  "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-                  "requires": {
-                    "dicer": "0.3.0"
-                  }
-                },
-                "http-errors": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-                  "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-                  "requires": {
-                    "depd": "~1.1.2",
-                    "inherits": "2.0.4",
-                    "setprototypeof": "1.2.0",
-                    "statuses": ">= 1.5.0 < 2",
-                    "toidentifier": "1.0.0"
-                  }
-                }
               }
             }
           }
@@ -10680,6 +10677,14 @@
             "apollo-reporting-protobuf": "^0.6.0",
             "apollo-server-caching": "^0.5.2",
             "apollo-server-env": "^2.4.5"
+          }
+        },
+        "busboy": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+          "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+          "requires": {
+            "dicer": "0.3.0"
           }
         },
         "dicer": {
@@ -10719,8 +10724,28 @@
           "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
           "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
           "requires": {
+            "busboy": "^0.3.1",
+            "http-errors": "^1.7.3",
+            "isobject": "^4.0.0",
             "object-path": "^0.11.4"
           }
+        },
+        "http-errors": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         },
         "lru-cache": {
           "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@babel/preset-env": "7.9.6",
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.9.0",
+    "@golevelup/nestjs-testing": "^0.1.2",
     "@graphql-codegen/cli": "1.20.0",
     "@graphql-codegen/introspection": "1.18.1",
     "@graphql-codegen/typescript": "1.20.0",


### PR DESCRIPTION
Closes #169 

Our Routes are secured by either using the newly created `AuthGuard` or the `AuthenticatedUser` class and function in `auth.guard.ts`.

Using  `AuthenticatedUser` we can get the userId directly from the header of the request. This means we no longer should be sending userId as a parameter to any graphQL queries or mutations.

For queries or mutations not taking userId as a parameter, I created the `AuthGuard` class. When placed on an endpoint it checks that the header has a valid access token and continues with the request. If the access token is invalid an error is thrown and the request is not processed.

**Notes**
Queries to our GraphQL server now requires a header with the following field
`Auhtorization: 'Bearer <valid-accesToken>'`

This is what it would look like in apollo studio
![image](https://user-images.githubusercontent.com/25574985/107086388-eef33080-67c7-11eb-8607-5496820b6fb3.png)


Ideally we'd have a script to generate access tokens, I haven't found a pretty solution I'm comfortable pushing at the moment. Feel free to work on this if it interests you.

You can get a valid access token by going to the network tab in your browser and looking at the header of a graphql query made when logged in.

![image](https://user-images.githubusercontent.com/25574985/107086633-485b5f80-67c8-11eb-87f3-89b2f8ddee10.png)

**Running e2e tests**
You will need to add a  `cypress.env.json` file in mull-ui-e2e. Take a look at the docs and resources channel to see what goes inside

