### PR TITLE
TASK-50: Save Messages to back end

### DIFF
--- a/apps/mull-api/src/app/app.module.ts
+++ b/apps/mull-api/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { EntitiesModule } from './entities';
 import { EventModule } from './event/event.module';
 import { LocationModule } from './location/location.module';
 import { MediaModule } from './media/media.module';
+import { PostModule } from './post/post.module';
 // Modules
 import { UserModule } from './user';
 
@@ -55,6 +56,7 @@ import { UserModule } from './user';
         credentials: true,
       },
       context: ({ req, res }) => ({ req, res }),
+      installSubscriptionHandlers: true,
     }),
     SessionModule.forRoot({
       session: {
@@ -64,6 +66,7 @@ import { UserModule } from './user';
         saveUninitialized: false,
       },
     }),
+    PostModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/mull-api/src/app/app.module.ts
+++ b/apps/mull-api/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { UserModule } from './user';
     MediaModule,
     AuthModule,
     LocationModule,
+    PostModule,
     TypeOrmModule.forRoot({
       type: 'mysql',
       host: environment.db.host,
@@ -66,7 +67,6 @@ import { UserModule } from './user';
         saveUninitialized: false,
       },
     }),
-    PostModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/mull-api/src/app/channel/inputs/channel.input.ts
+++ b/apps/mull-api/src/app/channel/inputs/channel.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { Channel } from '../../entities';
+
+@InputType()
+export class ChannelInput implements Partial<Channel> {
+  @Field()
+  id: number;
+}

--- a/apps/mull-api/src/app/entities/channel.entity.ts
+++ b/apps/mull-api/src/app/entities/channel.entity.ts
@@ -1,3 +1,4 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import {
   Column,
   Entity,
@@ -12,22 +13,29 @@ import { Post } from './post.entity';
 import { User } from './user.entity';
 
 @Entity()
+@ObjectType()
 export class Channel {
+  @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Field()
   @Column()
   name: string;
 
+  @Field(() => Int)
   @Column()
   rights: number;
 
+  @Field(() => Event)
   @ManyToOne(() => Event, (event) => event.channels)
   event: Event;
 
+  @Field(() => [Post])
   @OneToMany(() => Post, (post) => post.channel)
   posts: Post[];
 
+  @Field(() => [User])
   @ManyToMany(() => User)
   @JoinTable({ name: 'channel_participants' })
   participants: User[];

--- a/apps/mull-api/src/app/entities/post-reaction.entity.ts
+++ b/apps/mull-api/src/app/entities/post-reaction.entity.ts
@@ -1,18 +1,24 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Post } from './post.entity';
 import { User } from './user.entity';
 
 @Entity()
+@ObjectType()
 export class PostReaction {
+  @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Field(() => Int)
   @Column()
   type: number;
 
+  @Field(() => Post)
   @ManyToOne(() => Post, (post) => post.reactions)
   post: Post;
 
+  @Field(() => User)
   @ManyToOne(() => User, (user) => user.postReactions)
   user: User;
 }

--- a/apps/mull-api/src/app/entities/post.entity.ts
+++ b/apps/mull-api/src/app/entities/post.entity.ts
@@ -1,3 +1,4 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import {
   Column,
   Entity,
@@ -13,30 +14,38 @@ import { PostReaction } from './post-reaction.entity';
 import { User } from './user.entity';
 
 @Entity()
+@ObjectType()
 export class Post {
+  @Field(/* istanbul ignore next */ () => Int)
   @PrimaryGeneratedColumn()
   id: number;
 
-  @OneToOne(() => User)
-  @JoinColumn()
+  @Field(/* istanbul ignore next */ () => User)
+  @ManyToOne(/* istanbul ignore next */ () => User, /* istanbul ignore next */ (user) => user.posts)
   user: User;
 
-  @OneToOne(() => Post)
+  @Field({ nullable: true })
+  @OneToOne(/* istanbul ignore next */ () => Post)
   @JoinColumn()
-  parentPost: Post;
+  parentPost?: Post;
 
+  @Field()
   @Column()
   message: string;
 
+  @Field()
   @Column()
   createdTime: Date;
 
+  @Field(/* istanbul ignore next */ () => [Media], { nullable: true })
   @OneToMany(() => Media, (media) => media.post)
-  medias: Media[];
+  medias?: Media[];
 
-  @OneToMany(() => PostReaction, (reaction) => reaction.post)
-  reactions: PostReaction[];
+  @Field(/* istanbul ignore next */ () => [PostReaction], { nullable: true })
+  @OneToMany(/* istanbul ignore next */ () => PostReaction, (reaction) => reaction.post)
+  reactions?: PostReaction[];
 
-  @ManyToOne(() => Channel, (channel) => channel.posts)
+  @Field(/* istanbul ignore next */ () => Channel)
+  @ManyToOne(/* istanbul ignore next */ () => Channel, (channel) => channel.posts)
   channel: Channel;
 }

--- a/apps/mull-api/src/app/entities/user.entity.ts
+++ b/apps/mull-api/src/app/entities/user.entity.ts
@@ -13,6 +13,7 @@ import {
 import { Event } from './event.entity';
 import { Media } from './media.entity';
 import { PostReaction } from './post-reaction.entity';
+import { Post } from './post.entity';
 
 registerEnumType(RegistrationMethod, {
   name: 'RegistrationMethod',
@@ -99,4 +100,6 @@ export class User implements IUser {
   @Column()
   @Field()
   joinDate?: Date;
+  @OneToMany(/* istanbul ignore next */ () => Post, /* istanbul ignore next */ (post) => post.user)
+  posts?: Post[];
 }

--- a/apps/mull-api/src/app/post/inputs/parent-post.input.ts
+++ b/apps/mull-api/src/app/post/inputs/parent-post.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { Post } from '../../entities';
+
+@InputType()
+export class ParentPostInput implements Partial<Post> {
+  @Field(/* istanbul ignore next */ () => Int)
+  id: number;
+}

--- a/apps/mull-api/src/app/post/inputs/post-reaction.input.ts
+++ b/apps/mull-api/src/app/post/inputs/post-reaction.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { PostReaction } from '../../entities';
+
+@InputType()
+export class PostReactionInput implements Partial<PostReaction> {
+  @Field(/* istanbul ignore next */ () => Int)
+  id: number;
+}

--- a/apps/mull-api/src/app/post/inputs/post.input.ts
+++ b/apps/mull-api/src/app/post/inputs/post.input.ts
@@ -1,0 +1,37 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { ChannelInput } from '../../channel/inputs/channel.input';
+import { Media } from '../../entities';
+import { MediaInput } from '../../media/inputs/media.input';
+import { UserInput } from '../../user/inputs/user.input';
+import { ParentPostInput } from './parent-post.input';
+import { PostReactionInput } from './post-reaction.input';
+
+@InputType()
+export class CreatePostInput {
+  @Field(/* istanbul ignore next */ () => UserInput)
+  user: UserInput;
+
+  @Field()
+  message: string;
+
+  @Field()
+  createdTime: Date;
+
+  @Field(/* istanbul ignore next */ () => ChannelInput, { nullable: true }) //TODO: remove nullable in TASK-58
+  channel: ChannelInput;
+
+  @Field(/* istanbul ignore next */ () => ParentPostInput, { nullable: true })
+  parentPost?: ParentPostInput;
+
+  @Field(/* istanbul ignore next */ () => MediaInput, { nullable: true })
+  medias?: Media[];
+
+  @Field(/* istanbul ignore next */ () => PostReactionInput, { nullable: true })
+  reactions?: PostReactionInput[];
+}
+
+@InputType()
+export class UpdatePostInput extends CreatePostInput {
+  @Field(/* istanbul ignore next */ () => Int)
+  id: number;
+}

--- a/apps/mull-api/src/app/post/post.mockdata.ts
+++ b/apps/mull-api/src/app/post/post.mockdata.ts
@@ -1,13 +1,10 @@
 import { Post } from '../entities';
-import { mockAllEvents } from '../event/event.mockdata';
 import { mockAllUsers } from '../user/user.mockdata';
 import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
 
 const userA = mockAllUsers[0]; // id: 1
 const userB = mockAllUsers[1]; // id: 7
 const userC = mockAllUsers[2]; // id: 3
-
-const mockEventA = mockAllEvents[0];
 
 export const mockPartialPosts: CreatePostInput | UpdatePostInput = {
   id: 22,

--- a/apps/mull-api/src/app/post/post.mockdata.ts
+++ b/apps/mull-api/src/app/post/post.mockdata.ts
@@ -1,0 +1,44 @@
+import { Post } from '../entities';
+import { mockAllEvents } from '../event/event.mockdata';
+import { mockAllUsers } from '../user/user.mockdata';
+import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
+
+const userA = mockAllUsers[0]; // id: 1
+const userB = mockAllUsers[1]; // id: 7
+const userC = mockAllUsers[2]; // id: 3
+
+const mockEventA = mockAllEvents[0];
+
+export const mockPartialPosts: CreatePostInput | UpdatePostInput = {
+  id: 22,
+  user: { id: 23 },
+  message: 'This is a post',
+  createdTime: new Date('2020-10-27T01:31:00.000Z'),
+  channel: { id: 2 },
+};
+
+export const mockAllPosts: Post[] = [
+  {
+    id: 23,
+    user: userA,
+    message: 'This the first post',
+    createdTime: new Date('2020-10-27T01:31:00.000Z'),
+    //TODO: replace null with a mock channel
+    channel: null,
+  },
+
+  {
+    id: 24,
+    user: userB,
+    message: 'This the 2nd post',
+    createdTime: new Date('2020-10-27T01:31:00.000Z'),
+    channel: null,
+  },
+  {
+    id: 25,
+    user: userC,
+    message: 'This the 3rd post',
+    createdTime: new Date('2020-10-27T01:31:00.000Z'),
+    channel: null,
+  },
+];

--- a/apps/mull-api/src/app/post/post.module.ts
+++ b/apps/mull-api/src/app/post/post.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { EntitiesModule } from '../entities';
+import { PostResolver } from './post.resolver';
+import { PostService } from './post.service';
+
+@Module({
+  imports: [EntitiesModule],
+  providers: [PostService, PostResolver],
+  exports: [PostService],
+})
+export class PostModule {}

--- a/apps/mull-api/src/app/post/post.pubsub.ts
+++ b/apps/mull-api/src/app/post/post.pubsub.ts
@@ -1,0 +1,3 @@
+import { PubSub } from 'graphql-subscriptions';
+const pubSub = new PubSub();
+export default pubSub;

--- a/apps/mull-api/src/app/post/post.resolver.spec.ts
+++ b/apps/mull-api/src/app/post/post.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostResolver } from './post.resolver';
+
+describe('PostResolver', () => {
+  let resolver: PostResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostResolver],
+    }).compile();
+
+    resolver = module.get<PostResolver>(PostResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/apps/mull-api/src/app/post/post.resolver.spec.ts
+++ b/apps/mull-api/src/app/post/post.resolver.spec.ts
@@ -14,6 +14,7 @@ const mockPostService = () => ({
   getPost: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
   updatePost: jest.fn((mockPostData: UpdatePostInput) => ({ ...mockPostData })),
   deletePost: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
+  getAllPosts: jest.fn(() => mockAllPosts),
 });
 
 describe('PostResolver', () => {
@@ -34,6 +35,11 @@ describe('PostResolver', () => {
 
   it('should be defined', () => {
     expect(resolver).toBeDefined();
+  });
+
+  it('should get all posts', async () => {
+    const allPosts = await resolver.posts();
+    expect(allPosts).toEqual(mockAllPosts);
   });
 
   it('it should subscribe to new messages', async () => {

--- a/apps/mull-api/src/app/post/post.resolver.spec.ts
+++ b/apps/mull-api/src/app/post/post.resolver.spec.ts
@@ -1,18 +1,53 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
+import { mockAllPosts, mockPartialPosts } from './post.mockdata';
+import pubSub from './post.pubsub';
 import { PostResolver } from './post.resolver';
+import { PostService } from './post.service';
+
+jest.mock('./post.pubsub');
+
+const mockPostService = () => ({
+  createPost: jest.fn((mockPostData: CreatePostInput) => {
+    mockPostData;
+  }),
+  getPost: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
+  updatePost: jest.fn((mockPostData: UpdatePostInput) => ({ ...mockPostData })),
+  deletePost: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
+});
 
 describe('PostResolver', () => {
   let resolver: PostResolver;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PostResolver],
+      providers: [
+        PostResolver,
+        {
+          provide: PostService,
+          useFactory: mockPostService,
+        },
+      ],
     }).compile();
-
     resolver = module.get<PostResolver>(PostResolver);
   });
 
   it('should be defined', () => {
     expect(resolver).toBeDefined();
+  });
+
+  it('it should subscribe to new messages', async () => {
+    await resolver.post(mockPartialPosts as CreatePostInput);
+    expect(pubSub.publish).toHaveBeenCalled();
+  });
+
+  it('should update the post', async () => {
+    const updatedEvent = await resolver.updatePost(mockPartialPosts as UpdatePostInput);
+    expect(updatedEvent).toEqual(mockPartialPosts);
+  });
+
+  it('should return the deleted post', async () => {
+    const deletedPost = await resolver.deletePost(23);
+    expect(deletedPost).toEqual(mockAllPosts.find((post) => post.id === 23));
   });
 });

--- a/apps/mull-api/src/app/post/post.resolver.ts
+++ b/apps/mull-api/src/app/post/post.resolver.ts
@@ -1,0 +1,41 @@
+import { Args, Int, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
+import { PubSub } from 'graphql-subscriptions';
+import { Post } from '../entities';
+import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
+import { PostService } from './post.service';
+
+const pubSub = new PubSub();
+
+@Resolver(() => Post)
+export class PostResolver {
+  constructor(private readonly postService: PostService) {}
+
+  @Subscription(() => Post)
+  postAdded() {
+    return pubSub.asyncIterator(['postAdded']);
+  }
+
+  @Mutation(/* istanbul ignore next */ () => Post)
+  async post(@Args('post') post: CreatePostInput) {
+    const savedPost = this.postService.createPost(post);
+    pubSub.publish('postAdded', {
+      postAdded: savedPost,
+    });
+    return savedPost;
+  }
+
+  @Query(/* istanbul ignore next */ () => [Post])
+  async posts() {
+    return this.postService.getAllPosts();
+  }
+
+  @Mutation(/* istanbul ignore next */ () => Post)
+  async updateEvent(@Args('post') post: UpdatePostInput) {
+    return this.postService.updatePost(post);
+  }
+
+  @Mutation(/* istanbul ignore next */ () => Post)
+  async deleteEvent(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
+    return this.postService.deletePost(id);
+  }
+}

--- a/apps/mull-api/src/app/post/post.resolver.ts
+++ b/apps/mull-api/src/app/post/post.resolver.ts
@@ -1,16 +1,13 @@
 import { Args, Int, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
-import { PubSub } from 'graphql-subscriptions';
 import { Post } from '../entities';
 import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
+import pubSub from './post.pubsub';
 import { PostService } from './post.service';
-
-const pubSub = new PubSub();
 
 @Resolver(() => Post)
 export class PostResolver {
   constructor(private readonly postService: PostService) {}
-
-  @Subscription(() => Post)
+  @Subscription(/* istanbul ignore next */ () => Post)
   postAdded() {
     return pubSub.asyncIterator(['postAdded']);
   }
@@ -30,12 +27,12 @@ export class PostResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
-  async updateEvent(@Args('post') post: UpdatePostInput) {
+  async updatePost(@Args('post') post: UpdatePostInput) {
     return this.postService.updatePost(post);
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
-  async deleteEvent(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
+  async deletePost(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
     return this.postService.deletePost(id);
   }
 }

--- a/apps/mull-api/src/app/post/post.resolver.ts
+++ b/apps/mull-api/src/app/post/post.resolver.ts
@@ -1,4 +1,6 @@
+import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
+import { AuthGuard } from '../auth/auth.guard';
 import { Post } from '../entities';
 import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
 import pubSub from './post.pubsub';
@@ -13,6 +15,7 @@ export class PostResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
+  @UseGuards(AuthGuard)
   async post(@Args('post') post: CreatePostInput) {
     const savedPost = this.postService.createPost(post);
     pubSub.publish('postAdded', {
@@ -22,16 +25,19 @@ export class PostResolver {
   }
 
   @Query(/* istanbul ignore next */ () => [Post])
+  @UseGuards(AuthGuard)
   async posts() {
     return this.postService.getAllPosts();
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
+  @UseGuards(AuthGuard)
   async updatePost(@Args('post') post: UpdatePostInput) {
     return this.postService.updatePost(post);
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
+  @UseGuards(AuthGuard)
   async deletePost(@Args('id', { type: /* istanbul ignore next */ () => Int }) id: number) {
     return this.postService.deletePost(id);
   }

--- a/apps/mull-api/src/app/post/post.service.spec.ts
+++ b/apps/mull-api/src/app/post/post.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostService } from './post.service';
+
+describe('PostService', () => {
+  let service: PostService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostService],
+    }).compile();
+
+    service = module.get<PostService>(PostService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/mull-api/src/app/post/post.service.spec.ts
+++ b/apps/mull-api/src/app/post/post.service.spec.ts
@@ -1,12 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Post } from '../entities';
+import { CreatePostInput } from './inputs/post.input';
+import { mockAllPosts, mockPartialPosts } from './post.mockdata';
 import { PostService } from './post.service';
+
+const mockPostRepository = () => ({
+  create: jest.fn((mockUserData: CreatePostInput) => ({ ...mockUserData })),
+  findOne: jest.fn((id: number) => {
+    return mockAllPosts.find((post) => post.id === id);
+  }),
+  find: jest.fn(() => mockAllPosts),
+  update: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
+  delete: jest.fn((id: number) => mockAllPosts.find((post) => post.id === id)),
+  save: jest.fn((post: Post) => post),
+  createQueryBuilder: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    getQuery: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockReturnValue(mockAllPosts[0]),
+  })),
+  query: jest.fn().mockReturnThis(),
+});
 
 describe('PostService', () => {
   let service: PostService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PostService],
+      providers: [
+        PostService,
+        {
+          provide: getRepositoryToken(Post),
+          useFactory: mockPostRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<PostService>(PostService);
@@ -14,5 +47,25 @@ describe('PostService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should create the post', async () => {
+    const returnedPost = await service.createPost(mockPartialPosts as CreatePostInput);
+    expect(returnedPost).toEqual(returnedPost);
+  });
+
+  it('should fetch all posts', async () => {
+    const returnedPosts = await service.getAllPosts();
+    expect(returnedPosts).toEqual(mockAllPosts);
+  });
+
+  it('should update the post', async () => {
+    const updatedPost = await service.updatePost(mockAllPosts[0]);
+    expect(updatedPost).toEqual(mockAllPosts[0]);
+  });
+
+  it('should return the deleted event', async () => {
+    const deletedPost = await service.deletePost(23);
+    expect(deletedPost).toEqual(mockAllPosts.find((post) => post.id === 23));
   });
 });

--- a/apps/mull-api/src/app/post/post.service.ts
+++ b/apps/mull-api/src/app/post/post.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Post } from '../entities';
+import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
+
+@Injectable()
+export class PostService {
+  constructor(
+    @InjectRepository(Post)
+    private postRepository: Repository<Post>
+  ) {}
+
+  getPost(postId: number): Promise<Post> {
+    return this.postRepository.findOne(postId);
+  }
+
+  //TODO: add channel id and update name
+  getAllPosts(): Promise<Post[]> {
+    return this.postRepository.find();
+  }
+
+  async createPost(input: CreatePostInput): Promise<Post> {
+    return await this.postRepository.save(input);
+  }
+
+  async deletePost(postId: number): Promise<Post> {
+    const post = await this.getPost(postId);
+    await this.postRepository.delete(post.id);
+    return post;
+  }
+
+  async updatePost(input: UpdatePostInput): Promise<Post> {
+    await this.postRepository.update(input.id, { ...input });
+    return await this.getPost(input.id);
+  }
+}

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -2,6 +2,19 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type Channel {
+  event: Event!
+  id: Int!
+  name: String!
+  participants: [User!]!
+  posts: [Post!]!
+  rights: Int!
+}
+
+input ChannelInput {
+  id: Float!
+}
+
 input CreateEventInput {
   description: String!
   endDate: DateTime!
@@ -10,6 +23,16 @@ input CreateEventInput {
   restriction: Int!
   startDate: DateTime!
   title: String!
+}
+
+input CreatePostInput {
+  channel: ChannelInput
+  createdTime: DateTime!
+  medias: MediaInput
+  message: String!
+  parentPost: ParentPostInput
+  reactions: PostReactionInput
+  user: UserInput!
 }
 
 input CreateUserInput {
@@ -74,15 +97,20 @@ type Mutation {
   createEvent(event: CreateEventInput!): Event!
   createLocation(location: LocationInput!): Location!
   createUser(user: CreateUserInput!): User!
-  deleteEvent(id: Int!): Event!
+  deleteEvent(id: Int!): Post!
   deleteUser: User!
   joinEvent(eventId: Int!): Boolean!
   leaveEvent(eventId: Int!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
-  updateEvent(event: UpdateEventInput!): Event!
+  post(post: CreatePostInput!): Post!
+  updateEvent(post: UpdatePostInput!): Post!
   updateFile(newFile: Upload!, oldFile: MediaInput!): Media!
   updateUser(newAvatar: Upload, userInput: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!
+}
+
+input ParentPostInput {
+  id: Int!
 }
 
 type Point {
@@ -94,6 +122,28 @@ type Point {
 input PointInput {
   lat: Float!
   long: Float!
+}
+
+type Post {
+  channel: Channel!
+  createdTime: DateTime!
+  id: Int!
+  medias: [Media!]
+  message: String!
+  parentPost: Post
+  reactions: [PostReaction!]
+  user: User!
+}
+
+type PostReaction {
+  id: Int!
+  post: Post!
+  type: Int!
+  user: User!
+}
+
+input PostReactionInput {
+  id: Int!
 }
 
 type Query {
@@ -108,6 +158,7 @@ type Query {
   location(id: Int!): Location!
   participantEvents: [Event!]!
   portfolioCount: Int!
+  posts: [Post!]!
   user: User!
   users: [User!]!
 }
@@ -119,14 +170,19 @@ enum RegistrationMethod {
   TWITTER
 }
 
-input UpdateEventInput {
-  description: String
-  endDate: DateTime
+type Subscription {
+  postAdded: Post!
+}
+
+input UpdatePostInput {
+  channel: ChannelInput
+  createdTime: DateTime!
   id: Int!
-  location: LocationInput!
-  restriction: Int
-  startDate: DateTime
-  title: String
+  medias: MediaInput
+  message: String!
+  parentPost: ParentPostInput
+  reactions: PostReactionInput
+  user: UserInput!
 }
 
 input UpdateUserInput {
@@ -153,4 +209,8 @@ type User {
   password: String
   registrationMethod: RegistrationMethod!
   timezone: String!
+}
+
+input UserInput {
+  id: Int!
 }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -97,14 +97,16 @@ type Mutation {
   createEvent(event: CreateEventInput!): Event!
   createLocation(location: LocationInput!): Location!
   createUser(user: CreateUserInput!): User!
-  deleteEvent(id: Int!): Post!
+  deleteEvent(id: Int!): Event!
+  deletePost(id: Int!): Post!
   deleteUser: User!
   joinEvent(eventId: Int!): Boolean!
   leaveEvent(eventId: Int!): Boolean!
   login(loginInput: LoginInput!): LoginResult!
   post(post: CreatePostInput!): Post!
-  updateEvent(post: UpdatePostInput!): Post!
+  updateEvent(event: UpdateEventInput!): Event!
   updateFile(newFile: Upload!, oldFile: MediaInput!): Media!
+  updatePost(post: UpdatePostInput!): Post!
   updateUser(newAvatar: Upload, userInput: UpdateUserInput!): User!
   uploadFile(file: Upload!): Media!
 }
@@ -172,6 +174,16 @@ enum RegistrationMethod {
 
 type Subscription {
   postAdded: Post!
+}
+
+input UpdateEventInput {
+  description: String
+  endDate: DateTime
+  id: Int!
+  location: LocationInput!
+  restriction: Int
+  startDate: DateTime
+  title: String
 }
 
 input UpdatePostInput {


### PR DESCRIPTION
This PR implements #184 

To test:
1. `nx serve mull-api`
2. pop into `localhost:3333/graphql`
3. Run the `postAdded` subscriber first by following the docs section in the gql playground or see the attached screenshot
![image](https://user-images.githubusercontent.com/35787279/107861624-1b84f900-6e15-11eb-913c-d40d6d3cba63.png)

       You should see `listening...` in the output 
      ![image](https://user-images.githubusercontent.com/35787279/107861665-5be47700-6e15-11eb-8648-313b0fe2e133.png)


4. In a new tab, create a post using `createPost` mutation (see below for an example)
![image](https://user-images.githubusercontent.com/35787279/107861637-2c356f00-6e15-11eb-990a-850defb6f1e0.png)
5. Go back to the postAdded subscriber to see the message appear

Expected result:
![image](https://user-images.githubusercontent.com/35787279/107861656-4707e380-6e15-11eb-9661-0250c65f3ca5.png)




