### PR TITLE
BUG-12: Fix event start time that can come after the event end time during event creation

### DIFF
--- a/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
@@ -91,7 +91,6 @@ frameSizes.forEach((frame) => {
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
 
       cy.get('#startTime').type('11:20');
-
       cy.get('#endTime').type('08:20');
 
       cy.get('#eventTitle').type('test title');
@@ -102,18 +101,11 @@ frameSizes.forEach((frame) => {
       cy.get('#description').type('test description');
 
       cy.get('#location').click();
-      cy.get('#location-input-field').should('be.visible');
-
-      cy.get('#location-input-field').type('845 Rue Sherbrooke');
-      cy.get('#location-input-field-option-0', { timeout: 3500 }).should(
-        'contain.text',
-        '845 Rue Sherbrooke'
-      );
 
       cy.get('#location-input-field-option-0', { timeout: 5000 }).click();
       cy.get('[data-testid=pill-id-1]').click();
+
       cy.get('.create-event-button').click();
-      cy.get('.event-page-button').click();
 
       cy.get('#endTime ~ .error-message').should(
         'have.text',

--- a/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
@@ -87,7 +87,7 @@ frameSizes.forEach((frame) => {
       cy.get('#location ~ .error-message').should('have.text', 'Event Location is required.');
     });
 
-    it('should show an error when end time is greater than start time', () => {
+    it('should show an error when end time is greater than start time if the event is on the same day', () => {
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
 
       cy.get('#startTime').type('11:20');
@@ -111,6 +111,30 @@ frameSizes.forEach((frame) => {
         'have.text',
         'The end time must be after the start time.'
       );
+    });
+
+    it('should not show an error when end time is greater than start time if the event is on different days', () => {
+      cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
+
+      cy.get('#startTime').type('11:20');
+      cy.get('#endTime').type('08:20');
+
+      cy.get('#eventTitle').type('test title');
+
+      const tomorrow = new Date().getDate() + 1;
+      cy.get('.-today').click();
+      cy.contains(tomorrow).click();
+
+      cy.get('#description').type('test description');
+
+      cy.get('#location').click();
+
+      cy.get('#location-input-field-option-0', { timeout: 5000 }).click();
+      cy.get('[data-testid=pill-id-1]').click();
+
+      cy.get('.create-event-button').click();
+
+      cy.get('#endTime ~ .error-message').should('not.exist');
     });
 
     it('should show a successful submission message', () => {

--- a/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
@@ -87,6 +87,40 @@ frameSizes.forEach((frame) => {
       cy.get('#location ~ .error-message').should('have.text', 'Event Location is required.');
     });
 
+    it('should show an error when end time is greater than start time', () => {
+      cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
+
+      cy.get('#startTime').type('11:20');
+
+      cy.get('#endTime').type('08:20');
+
+      cy.get('#eventTitle').type('test title');
+
+      cy.get('.-today').click();
+      cy.get('.-today').click();
+
+      cy.get('#description').type('test description');
+
+      cy.get('#location').click();
+      cy.get('#location-input-field').should('be.visible');
+
+      cy.get('#location-input-field').type('845 Rue Sherbrooke');
+      cy.get('#location-input-field-option-0', { timeout: 3500 }).should(
+        'contain.text',
+        '845 Rue Sherbrooke'
+      );
+
+      cy.get('#location-input-field-option-0', { timeout: 5000 }).click();
+      cy.get('[data-testid=pill-id-1]').click();
+      cy.get('.create-event-button').click();
+      cy.get('.event-page-button').click();
+
+      cy.get('#endTime ~ .error-message').should(
+        'have.text',
+        'The end time must be after the start time.'
+      );
+    });
+
     it('should show a successful submission message', () => {
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
 

--- a/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
@@ -87,7 +87,7 @@ frameSizes.forEach((frame) => {
       cy.get('#location ~ .error-message').should('have.text', 'Event Location is required.');
     });
 
-    it('should show an error when end time is greater than start time if the event is on the same day', () => {
+    const fillEventForm = () => {
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
 
       cy.get('#startTime').type('11:20');
@@ -95,15 +95,19 @@ frameSizes.forEach((frame) => {
 
       cy.get('#eventTitle').type('test title');
 
-      cy.get('.-today').click();
-      cy.get('.-today').click();
-
       cy.get('#description').type('test description');
 
       cy.get('#location').click();
 
       cy.get('#location-input-field-option-0', { timeout: 5000 }).click();
       cy.get('[data-testid=pill-id-1]').click();
+    };
+
+    it('should show an error when end time is greater than start time if the event is on the same day', () => {
+      fillEventForm();
+
+      cy.get('.-today').click();
+      cy.get('.-today').click();
 
       cy.get('.create-event-button').click();
 
@@ -114,23 +118,11 @@ frameSizes.forEach((frame) => {
     });
 
     it('should not show an error when end time is greater than start time if the event is on different days', () => {
-      cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
-
-      cy.get('#startTime').type('11:20');
-      cy.get('#endTime').type('08:20');
-
-      cy.get('#eventTitle').type('test title');
+      fillEventForm();
 
       const tomorrow = new Date().getDate() + 1;
       cy.get('.-today').click();
       cy.contains(tomorrow).click();
-
-      cy.get('#description').type('test description');
-
-      cy.get('#location').click();
-
-      cy.get('#location-input-field-option-0', { timeout: 5000 }).click();
-      cy.get('[data-testid=pill-id-1]').click();
 
       cy.get('.create-event-button').click();
 

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -4,6 +4,7 @@ import { EventRestriction, EventRestrictionMap, ICreateEventForm } from '@mull/t
 import { FormikTouched, FormikValues, setNestedObjectValues, useFormik } from 'formik';
 import { History } from 'history';
 import { cloneDeep, isEmpty } from 'lodash';
+import moment from 'moment';
 import React, { ChangeEvent, useState } from 'react';
 import { toast } from 'react-toastify';
 import * as Yup from 'yup';
@@ -88,7 +89,12 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
           return diff <= 30 * DAY_IN_MILLISECONDS;
         }),
       startTime: Yup.string().required('Start Time is required.'),
-      endTime: Yup.string().required('End Time is required.'),
+      endTime: Yup.string()
+        .required('End Time is required.')
+        .test('is-greater', 'The end time must be after the start time.', function (value) {
+          const { startTime } = this.parent;
+          return moment(value, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
+        }),
       eventTitle: Yup.string()
         .required('Event Title is required.')
         .max(65, 'Event Title length must be under 65 characters.'),

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -96,7 +96,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
           'The end time must be after the start time.',
           function (endTime) {
             const { startTime, startDate, endDate } = this.parent;
-            if (startDate < endDate) return true;
+            if (endDate && startDate < endDate) return true;
             return moment(endTime, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
           }
         ),

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -91,9 +91,9 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
       startTime: Yup.string().required('Start Time is required.'),
       endTime: Yup.string()
         .required('End Time is required.')
-        .test('is-greater', 'The end time must be after the start time.', function (value) {
+        .test('is-greater', 'The end time must be after the start time.', function (endTime) {
           const { startTime } = this.parent;
-          return moment(value, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
+          return moment(endTime, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
         }),
       eventTitle: Yup.string()
         .required('Event Title is required.')

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -91,10 +91,15 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
       startTime: Yup.string().required('Start Time is required.'),
       endTime: Yup.string()
         .required('End Time is required.')
-        .test('is-greater', 'The end time must be after the start time.', function (endTime) {
-          const { startTime } = this.parent;
-          return moment(endTime, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
-        }),
+        .test(
+          'endTime is after startTime',
+          'The end time must be after the start time.',
+          function (endTime) {
+            const { startTime, startDate, endDate } = this.parent;
+            if (startDate < endDate) return true;
+            return moment(endTime, 'HH:mm').isSameOrAfter(moment(startTime, 'HH:mm'));
+          }
+        ),
       eventTitle: Yup.string()
         .required('Event Title is required.')
         .max(65, 'Event Title length must be under 65 characters.'),


### PR DESCRIPTION
closes #163
To prevent users from creating an event that has a start time after the end time. 
![image](https://user-images.githubusercontent.com/36641869/107863180-137e8680-6e20-11eb-81ce-e9de91b92028.png)
