### PR TITLE
US-7.2: Müll-Profile

### DIFF
--- a/apps/mull-api/src/app/media/media.mockdata.ts
+++ b/apps/mull-api/src/app/media/media.mockdata.ts
@@ -35,8 +35,8 @@ export const mockInvalidFile: FileUpload = {
 };
 
 export const mockMediaInput: MediaInput = {
-  id: 2,
-  mediaType: 'png',
+  id: 1,
+  mediaType: 'jpeg',
 };
 
 export const mockAllMedias: Media[] = [
@@ -45,5 +45,5 @@ export const mockAllMedias: Media[] = [
     mediaType: 'jpeg',
     post: null,
   },
-  { id: 2, mediaType: 'jpeg', post: null },
+  { id: 2, mediaType: 'png', post: null },
 ];

--- a/apps/mull-api/src/app/media/media.resolver.spec.ts
+++ b/apps/mull-api/src/app/media/media.resolver.spec.ts
@@ -3,7 +3,7 @@ import { createWriteStream, renameSync, unlinkSync } from 'fs';
 import { FileUpload } from 'graphql-upload';
 import { join } from 'path';
 import { Media } from '../entities';
-import { mockAllMedias, mockFileJPEG, mockMediaInput } from './media.mockdata';
+import { mockAllMedias, mockFileJPEG, mockFilePNG, mockMediaInput } from './media.mockdata';
 import { MediaResolver } from './media.resolver';
 import { MediaService } from './media.service';
 
@@ -25,11 +25,7 @@ const mockMediaService = () => ({
     });
   }),
   uploadFile: jest.fn(() => {
-    return {
-      id: 1,
-      mediaType: 'jpeg',
-      post: null,
-    };
+    return mockAllMedias[0];
   }),
   updateFilename: jest.fn(
     (mockPrevFilename: string, mockNextFilename: number, mockFileType: string) => {
@@ -41,11 +37,7 @@ const mockMediaService = () => ({
     }
   ),
   updateFile: jest.fn(() => {
-    return {
-      id: 2,
-      mediaType: 'jpeg',
-      post: null,
-    };
+    return mockAllMedias[1];
   }),
 });
 
@@ -80,7 +72,7 @@ describe('MediaResolver', () => {
   });
 
   it('should update a file', async () => {
-    const mockUpdatedMedia = await resolver.updateFile(mockFileJPEG, mockMediaInput);
+    const mockUpdatedMedia = await resolver.updateFile(mockFilePNG, mockMediaInput);
     expect(mockUpdatedMedia).toEqual(mockAllMedias[1]);
   });
 });

--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -13,15 +13,16 @@ import {
 import { MediaService } from './media.service';
 
 const mockMediaRepository = () => ({
-  findOne: jest.fn((id: number) => mockAllMedias[id - 1]),
+  findOne: jest.fn((id: number) => mockAllMedias.find((media) => media.id === id)),
   save: jest.fn((file: Media) => {
     file.id = file.mediaType == 'jpeg' ? 1 : 2;
     file.post = null;
     return file;
   }),
   update: jest.fn((id: number) => {
-    return { id: id, mediaType: id == 2 ? 'jpeg' : 'png', post: null };
+    return { id: id, mediaType: 'png', post: null };
   }),
+  delete: jest.fn((id: number) => mockAllMedias.find((media) => media.id === id)),
 });
 
 describe('MediaService', () => {
@@ -102,8 +103,7 @@ describe('MediaService', () => {
   });
 
   it('should update a file', async () => {
-    await service.uploadFile(mockFilePNG);
-    const updatedFile = await service.updateFile(mockFileJPEG, mockMediaInput);
+    const updatedFile = await service.updateFile(mockFilePNG, mockMediaInput);
     expect(updatedFile).toEqual(mockAllMedias[1]);
   });
 
@@ -111,5 +111,10 @@ describe('MediaService', () => {
     await expect(() => service.updateFile(mockInvalidFile, mockMediaInput)).rejects.toThrow(
       InternalServerErrorException
     );
+  });
+
+  it('should return the deleted media', async () => {
+    const deletedMedia = await service.deleteMedia(1);
+    expect(deletedMedia).toEqual(mockAllMedias[0]);
   });
 });

--- a/apps/mull-api/src/app/media/media.service.ts
+++ b/apps/mull-api/src/app/media/media.service.ts
@@ -27,24 +27,17 @@ export class MediaService {
   }
 
   /**
-   * Delete the old file and upload new file (while keeping the same mediaId)
+   * Delete the old file and upload new file
    * @param newFile new file to upload
    * @param oldFile old file to delete
    */
   async updateFile(newFile: FileUpload, oldFile: MediaInput): Promise<Media> {
-    const mediaIdToKeep = oldFile.id;
     try {
       this.deleteStoredFile(oldFile);
-      await this.saveFile(newFile);
-      const newFileType = newFile.mimetype.split('/')[1];
-      this.updateFilename(newFile.filename, mediaIdToKeep, newFileType);
-      if (oldFile.mediaType != newFileType) {
-        await this.mediaRepository.update(mediaIdToKeep, { mediaType: newFileType });
-      }
+      return this.uploadFile(newFile);
     } catch (err) {
       throw new InternalServerErrorException();
     }
-    return this.getMedia(mediaIdToKeep);
   }
 
   saveFile({ createReadStream, filename }: FileUpload): Promise<boolean> {
@@ -63,6 +56,12 @@ export class MediaService {
     const fileType = mediaType.split('/')[1];
     const newMedia = new Media(fileType);
     return await this.mediaRepository.save(newMedia);
+  }
+
+  async deleteMedia(id: number): Promise<Media> {
+    const media = this.getMedia(id);
+    await this.mediaRepository.delete(id);
+    return media;
   }
 
   updateFilename(prevFilename: string, nextFilename: number, fileType: string): boolean {

--- a/apps/mull-api/src/app/user/user.resolver.spec.ts
+++ b/apps/mull-api/src/app/user/user.resolver.spec.ts
@@ -3,7 +3,7 @@ import { UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mockAllEvents } from '../event/event.mockdata';
 import { EventService } from '../event/event.service';
-import { mockFileJPEG, mockFilePNG } from '../media/media.mockdata';
+import { mockAllMedias, mockFileJPEG, mockFilePNG } from '../media/media.mockdata';
 import { MediaService } from '../media/media.service';
 import { CreateUserInput, UpdateUserInput } from './inputs/user.input';
 import {
@@ -41,18 +41,13 @@ const mockEventService = () => ({
 
 const mockMediaService = () => ({
   uploadFile: jest.fn(() => {
-    return {
-      id: 1,
-      mediaType: 'jpeg',
-      post: null,
-    };
+    return mockAllMedias[0];
   }),
   updateFile: jest.fn(() => {
-    return {
-      id: 2,
-      mediaType: 'png',
-      post: null,
-    };
+    return mockAllMedias[1];
+  }),
+  deleteMedia: jest.fn(() => {
+    return mockAllMedias[0];
   }),
 });
 

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -48,15 +48,20 @@ export class UserResolver {
   ) {
     var user = await this.userService.getUser(userInput.id);
     if (newAvatar) {
-      var media = user.avatar
-        ? await this.mediaService.updateFile(newAvatar, user.avatar)
-        : await this.mediaService.uploadFile(newAvatar);
+      if (user.avatar) {
+        var oldMediaId = user.avatar.id;
+        var media = await this.mediaService.updateFile(newAvatar, user.avatar);
+      } else {
+        var media = await this.mediaService.uploadFile(newAvatar);
+      }
       userInput = {
         ...userInput,
         avatar: media,
       };
     }
-    return await this.userService.updateUser(userInput);
+    const updatedUser = await this.userService.updateUser(userInput);
+    if (newAvatar && !!user.avatar) this.mediaService.deleteMedia(oldMediaId);
+    return updatedUser;
   }
 
   @Mutation(/* istanbul ignore next */ () => User)

--- a/apps/mull-api/src/app/user/user.resolver.ts
+++ b/apps/mull-api/src/app/user/user.resolver.ts
@@ -46,7 +46,7 @@ export class UserResolver {
     @Args('newAvatar', { type: /* istanbul ignore next */ () => GraphQLUpload, nullable: true })
     newAvatar: FileUpload
   ) {
-    var user = await this.userService.getUser(userInput.id);
+    const user = await this.userService.getUser(userInput.id);
     if (newAvatar) {
       if (user.avatar) {
         var oldMediaId = user.avatar.id;

--- a/apps/mull-ui-e2e/cypress.json
+++ b/apps/mull-ui-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "videosFolder": "../../dist/cypress/apps/mull-ui-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/mull-ui-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/mull-ui-e2e/src/integration/US-2.7.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-2.7.spec.ts
@@ -25,8 +25,8 @@ frameSizes.forEach((frame) => {
       cy.get('.create-event-button').click();
       cy.get('.event-page-button').click();
 
-      cy.get('[data-testid=subnavigation-myevents-button]').click().wait(200);
-      cy.get('.event-card-container').last().click().wait(200);
+      cy.visit('http://localhost:4200/home/myevents');
+      cy.get('.event-card-container').last().click();
 
       cy.get('.title').should('have.text', 'Title for US-2.7: Preview Event E2E');
       cy.get('.event-image').should('have.attr', 'src');

--- a/apps/mull-ui-e2e/src/integration/US-7.2.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-7.2.spec.ts
@@ -1,0 +1,55 @@
+/// <reference types="Cypress" />
+import 'cypress-file-upload';
+import * as faker from 'faker';
+import { frameSizes } from './../fixtures/frame-sizes';
+
+frameSizes.forEach((frame) => {
+  describe(`US-7.2: Müll Profile (${frame.name} view)`, () => {
+    const email = faker.internet.email();
+    before(() => {
+      cy.visit('http://localhost:4200/register');
+      cy.get('#name').type('Andrea Gloria');
+      cy.get('#email').type(email);
+      cy.get('#password').type('password');
+      cy.get('.register-button').click();
+    });
+
+    beforeEach(() => {
+      cy.viewport(frame.res[0], frame.res[1]);
+      cy.interceptGraphQLReqs();
+    });
+
+    it(`should show the user's expected profile`, () => {
+      cy.visit('http://localhost:4200/login');
+      cy.get('#email').type(email);
+      cy.get('#password').type('password');
+      cy.get('.login').click().wait('@Login');
+      cy.visit('http://localhost:4200/profile');
+
+      cy.get('[data-testid=userName]').should('have.text', 'Andrea Gloria');
+      cy.get('[data-testid=userDescription]').should('have.text', '');
+      cy.get('[data-testid=friendCount]').should('have.text', '0Friends');
+      cy.get('[data-testid=portfolioCount]').should('have.text', '0Portfolio');
+      cy.get('[data-testid=hostingCount]').should('have.text', '0Hosting');
+    });
+
+    it(`should show the user's updated profile`, () => {
+      cy.visit('http://localhost:4200/login');
+      cy.get('#email').type(email);
+      cy.get('#password').type('password');
+      cy.get('.login').click().wait('@Login');
+      cy.visit('http://localhost:4200/profile/edit').wait('@User');
+      cy.get('#description').clear().type('This is my updated description!');
+      cy.get('.save-button').click();
+
+      cy.get('[data-testid=userName]').should('have.text', 'Andrea Gloria');
+      cy.get('[data-testid=userDescription]').should(
+        'have.text',
+        'This is my updated description!'
+      );
+      cy.get('[data-testid=friendCount]').should('have.text', '0Friends');
+      cy.get('[data-testid=portfolioCount]').should('have.text', '0Portfolio');
+      cy.get('[data-testid=hostingCount]').should('have.text', '0Hosting');
+    });
+  });
+});

--- a/apps/mull-ui-e2e/src/support/commands.ts
+++ b/apps/mull-ui-e2e/src/support/commands.ts
@@ -13,6 +13,7 @@ const jwt = require('jsonwebtoken');
 declare namespace Cypress {
   interface Chainable<Subject> {
     mockRefreshRequest(userId?): void;
+    interceptGraphQLReqs(): void;
   }
 }
 //
@@ -26,6 +27,25 @@ Cypress.Commands.add('mockRefreshRequest', (userId = 1) => {
     },
   });
 });
+
+/**
+ * Intercepts GQL requests and checks if the requests contain specific operation names, and are
+ * then aliased so that the E2E tests can refer to them.
+ * This is used as an alternative to cy.wait(int) as it is an anti-pattern,
+ * and cy.wait(alias) is the correct approach in order to reduce flaky tests.
+ * Ref: https://docs.cypress.io/api/commands/wait.html#Alias
+ */
+Cypress.Commands.add('interceptGraphQLReqs', () => {
+  return cy.intercept('POST', 'localhost:3333/graphql', (req) => {
+    if (req.body.operationName.includes('User')) {
+      req.alias = 'User';
+    }
+    if (req.body.operationName.includes('Login')) {
+      req.alias = 'Login';
+    }
+  });
+});
+
 //
 // -- This is a child command --
 // Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })

--- a/apps/mull-ui/src/app/components/profile-header/__snapshots__/profile-header.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/profile-header/__snapshots__/profile-header.spec.tsx.snap
@@ -7,7 +7,9 @@ exports[`ProfileHeader should match snapshot 1`] = `
   <div
     className="user-name-container"
   >
-    <h1>
+    <h1
+      data-testid="userName"
+    >
       
     </h1>
     <button
@@ -45,6 +47,7 @@ exports[`ProfileHeader should match snapshot 1`] = `
     >
       <button
         className="profile-stats"
+        data-testid="portfolioCount"
       >
         0
         <br />
@@ -52,6 +55,7 @@ exports[`ProfileHeader should match snapshot 1`] = `
       </button>
       <button
         className="profile-stats"
+        data-testid="friendCount"
       >
         0
         <br />
@@ -59,6 +63,7 @@ exports[`ProfileHeader should match snapshot 1`] = `
       </button>
       <button
         className="profile-stats"
+        data-testid="hostingCount"
       >
         0
         <br />
@@ -69,7 +74,9 @@ exports[`ProfileHeader should match snapshot 1`] = `
   <div
     className="user-description-container"
   >
-    <p>
+    <p
+      data-testid="userDescription"
+    >
       
     </p>
   </div>

--- a/apps/mull-ui/src/app/components/profile-header/profile-header.tsx
+++ b/apps/mull-ui/src/app/components/profile-header/profile-header.tsx
@@ -30,18 +30,18 @@ export function checkFriendStatus(isFriend: boolean) {
 export interface profileHeaderProps {
   userName?: string;
   userPicture?: string;
-  userPortfolio?: number;
-  userFriends?: number;
-  userHosting?: number;
+  portfolioCount?: number;
+  friendCount?: number;
+  hostingCount?: number;
   userDescription?: string;
 }
 
 export const ProfileHeader = ({
   userName = '',
   userPicture = '',
-  userPortfolio = 0,
-  userFriends = 0,
-  userHosting = 0,
+  portfolioCount = 0,
+  friendCount = 0,
+  hostingCount = 0,
   userDescription = '',
 }: profileHeaderProps) => {
   // TODO: Check UserID, if currentUserID == profileUserID, then it is true, so return without the Friend button, otherwise return with the Friend button
@@ -51,7 +51,7 @@ export const ProfileHeader = ({
   return (
     <div className="profile-header-container">
       <div className="user-name-container">
-        <h1>{userName}</h1>
+        <h1 data-testid="userName">{userName}</h1>
         <button className="share-button">
           <FontAwesomeIcon icon={faShareAlt} />
         </button>
@@ -63,18 +63,18 @@ export const ProfileHeader = ({
             isCurrentUser ? 'profile-side-container for-current-user' : 'profile-side-container'
           }
         >
-          <button className="profile-stats">
-            {userPortfolio}
+          <button className="profile-stats" data-testid="portfolioCount">
+            {portfolioCount}
             <br />
             Portfolio
           </button>
-          <button className="profile-stats">
-            {userFriends}
+          <button className="profile-stats" data-testid="friendCount">
+            {friendCount}
             <br />
             Friends
           </button>
-          <button className="profile-stats">
-            {userHosting}
+          <button className="profile-stats" data-testid="hostingCount">
+            {hostingCount}
             <br />
             Hosting
           </button>
@@ -82,7 +82,7 @@ export const ProfileHeader = ({
         </div>
       </div>
       <div className="user-description-container">
-        <p>{userDescription}</p>
+        <p data-testid="userDescription">{userDescription}</p>
       </div>
     </div>
   );

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditProfile should match snapshot 1`] = `
+<div
+  className="page-container"
+>
+  <button
+    className="mull-back-button undefined"
+    data-testid="mull-back-button"
+    onClick={[Function]}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-left fa-w-10 mull-back-button-icon"
+      data-icon="chevron-left"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    <div
+      className="mull-back-button-text"
+    >
+      Profile
+    </div>
+  </button>
+  <form
+    className="edit-profile-container"
+    onSubmit={[Function]}
+  >
+    <p
+      className="edit-header"
+    >
+      Edit Profile
+    </p>
+    <div
+      className="custom-file-upload-container"
+    >
+      <label
+        className="image-uploaded"
+        htmlFor="imageFile"
+      >
+        <img
+          alt="Event"
+          className="custom-file-upload-image"
+          src="./assets/icons/icon-192x192.png"
+        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-pencil-alt fa-w-16 custom-file-upload-pencil-icon"
+          data-icon="pencil-alt"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </label>
+      <input
+        accept="image/*"
+        className="custom-file-upload-input"
+        data-testid="file"
+        id="imageFile"
+        onChange={[Function]}
+        type="file"
+      />
+    </div>
+    <div
+      className="custom-text-input-container "
+    >
+      <label
+        className="custom-text-input-label"
+        htmlFor="displayName"
+      >
+        Display Name
+      </label>
+      <input
+        className="custom-text-input input-border "
+        data-testid="custom-text-input"
+        id="displayName"
+        name="displayName"
+        onChange={[Function]}
+        type="text"
+        value="Jane Doe"
+      />
+    </div>
+    <label
+      className="description-label"
+      htmlFor="description"
+    >
+      Description
+    </label>
+    <textarea
+      className="description-msg "
+      id="description"
+      onChange={[Function]}
+      rows={6}
+      value="a description"
+    />
+    <button
+      className="mull-button save-button"
+      data-testid="mull-button"
+      onClick={[Function]}
+      type="submit"
+    >
+      Save
+    </button>
+  </form>
+</div>
+`;

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.spec.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.spec.tsx
@@ -1,88 +1,141 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import '@testing-library/jest-dom/extend-expect';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { createMemoryHistory, History } from 'history';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
+import renderer, { act as actRenderer } from 'react-test-renderer';
 import { ROUTES } from '../../../../../src/constants';
+import { UserDocument, UserQuery } from '../../../../generated/graphql';
 import { UserProvider } from '../../../context/user.context';
 import EditProfile from './edit-profile';
 
 describe('EditProfile', () => {
-  const renderHelper = (history: History) => {
-    const setUserId = jest.fn();
-    const userId = null;
-    const { location } = window;
-    // Stops tests from being redirected to OAuth Provider websites
-    beforeEach(() => {
-      delete window.location;
-      window.location = {
-        assign: jest.fn(),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any;
-    });
-    afterEach(() => {
-      window.location = location;
-    });
-
+  const renderHelper = (history, mocks: MockedResponse[]) => {
     return (
-      <UserProvider value={{ userId, setUserId }}>
-        <Router history={history}>
-          <EditProfile />
-        </Router>
+      <UserProvider value={{ userId: 1, setUserId: jest.fn() }}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <EditProfile history={history} />
+          </Router>
+        </MockedProvider>
       </UserProvider>
     );
   };
 
   it('should render successfully', () => {
-    const { baseElement } = render(<EditProfile />);
+    const history = createMemoryHistory();
+    history.push(ROUTES.PROFILE.EDIT);
+
+    const { baseElement } = render(renderHelper(history, null));
     expect(baseElement).toBeTruthy();
   });
 
-  it('should upload an image', async () => {
-    window.URL.createObjectURL = jest.fn();
+  it('should match snapshot', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UserDocument,
+        },
+        result: {
+          data: {
+            user: {
+              id: 1,
+              name: 'Jane Doe',
+              description: 'a description',
+              avatar: null,
+            },
+          } as UserQuery,
+        },
+      },
+    ];
+
     const history = createMemoryHistory();
-    history.push(ROUTES.PROFILE.EDIT);
-    const utils = render(renderHelper(history));
-    const file = new File(['zoro'], 'zoro.png', { type: 'image/png' });
-    const imageInput = utils.getByTestId('file') as HTMLInputElement;
-    user.upload(imageInput, file);
-    expect(imageInput.files[0]).toStrictEqual(file);
+    history.push(ROUTES.PROFILE.DISPLAY);
+    await actRenderer(async () => {
+      const tree = renderer.create(renderHelper(history, mocks));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(tree.toJSON()).toMatchSnapshot();
+    });
   });
 
   it('should have validation errors', async () => {
     const history = createMemoryHistory();
     history.push(ROUTES.PROFILE.EDIT);
-    const utils = render(renderHelper(history));
-    const submitButton = utils.container.querySelector('button[class="mull-button save-button"]');
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UserDocument,
+        },
+        result: {
+          data: {
+            user: {
+              id: 1,
+              name: '',
+              description: 'a description',
+              avatar: null,
+            },
+          } as UserQuery,
+        },
+      },
+    ];
 
-    await waitFor(() => {
-      fireEvent.click(submitButton);
+    await act(async () => {
+      const utils = render(renderHelper(history, mocks));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const saveButton = utils.container.querySelector('button[data-testid="mull-button"]');
+
+      await waitFor(() => {
+        fireEvent.click(saveButton);
+      });
+
+      const error = utils.container.querySelector('span[class="error-message"]');
+      expect(error).toHaveTextContent('Display name is required');
     });
-
-    const error = utils.container.querySelector('span[class="error-message"]');
-    expect(error).toHaveTextContent('Display name is required');
   });
 
   it('should submit the edit profile form', async () => {
     const history = createMemoryHistory();
     history.push(ROUTES.PROFILE.EDIT);
-    const utils = render(renderHelper(history));
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UserDocument,
+        },
+        result: {
+          data: {
+            user: {
+              id: 1,
+              name: 'Jane Doe',
+              description: 'a description',
+              avatar: null,
+            },
+          } as UserQuery,
+        },
+      },
+    ];
 
-    window.URL.createObjectURL = jest.fn();
-    const file = new File(['zoro'], 'zoro.png', { type: 'image/png' });
-    const imageInput = utils.getByTestId('file') as HTMLInputElement;
-    user.upload(imageInput, file);
+    await act(async () => {
+      const utils = render(renderHelper(history, mocks));
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
-    let input = utils.getByLabelText('Display Name');
-    fireEvent.change(input, { target: { value: 'Bob' } });
-    input = utils.getByLabelText('Description');
-    fireEvent.change(input, { target: { value: 'bob the builder' } });
+      window.URL.createObjectURL = jest.fn();
+      const file = new File(['zoro'], 'zoro.png', { type: 'image/png' });
+      const imageInput = utils.getByTestId('file') as HTMLInputElement;
+      await waitFor(() => {
+        user.upload(imageInput, file);
+      });
+      let input = utils.getByLabelText('Display Name');
+      fireEvent.change(input, { target: { value: 'Bob' } });
+      input = utils.getByLabelText('Description');
+      fireEvent.change(input, { target: { value: 'bob the builder' } });
 
-    const submitButton = utils.container.querySelector('button[class="mull-button save-button"]');
+      const submitButton = utils.container.querySelector('button[class="mull-button save-button"]');
 
-    await waitFor(() => {
-      fireEvent.click(submitButton);
+      await waitFor(() => {
+        fireEvent.click(submitButton);
+      });
     });
   });
 });

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
@@ -1,22 +1,76 @@
 import { IProfileEditForm } from '@mull/types';
 import { FormikTouched, FormikValues, setNestedObjectValues, useFormik } from 'formik';
+import { History } from 'history';
 import { isEmpty } from 'lodash';
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import * as Yup from 'yup';
+import { ROUTES } from '../../../../constants';
+import { User, useUpdateUserMutation, useUserQuery } from '../../../../generated/graphql';
+import { avatarUrl } from '../../../../utilities';
 import { CustomFileUpload, CustomTextInput } from '../../../components';
 import { MullBackButton } from '../../../components/mull-back-button/mull-back-button';
 import MullButton from '../../../components/mull-button/mull-button';
+import { useToast } from '../../../hooks/useToast';
 import './edit-profile.scss';
 
-const EditProfile = () => {
-  // TODO: Add initial profile image if user has one
-  // TODO: If user does not have an image, set to a default image
-  const [imageURLFile, setImageURLFile] = useState<string>(
-    'https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg'
-  );
+export interface EditProfilePageProps {
+  history: History;
+}
 
-  // Uploaded image file blob
+const EditProfile = ({ history }: EditProfilePageProps) => {
+  const [imageURLFile, setImageURLFile] = useState<string>('');
   const [file, setFile] = useState<File>(null);
+  const { data: userData, loading: userLoading } = useUserQuery();
+  const [updateUser] = useUpdateUserMutation();
+  const { updateToast, notifyToast } = useToast();
+
+  const formik = useFormik<IProfileEditForm>({
+    initialValues: {
+      displayName: '',
+      description: '',
+      imageFile: '',
+    },
+    validationSchema: Yup.object({
+      displayName: Yup.string().required('Display name is required'),
+    }),
+
+    onSubmit: async () => {
+      const errors = await formik.validateForm();
+      if (isEmpty(errors)) {
+        notifyToast('Submitting User Profile...');
+        try {
+          await updateUser({
+            variables: {
+              newAvatar: file,
+              userInput: {
+                id: userData.user.id,
+                name: formik.values.displayName,
+                description: formik.values.description,
+              },
+            },
+          });
+          updateToast(toast.TYPE.SUCCESS, 'Profile Updated');
+          history.push(ROUTES.PROFILE.DISPLAY);
+        } catch (err) {
+          updateToast(toast.TYPE.ERROR, 'Error: Failed To Update Profile');
+          console.error(err);
+        }
+      } else {
+        formik.setTouched(setNestedObjectValues<FormikTouched<FormikValues>>(errors, true));
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!userLoading) {
+      setImageURLFile(avatarUrl(userData.user as User));
+      formik.setFieldValue('displayName', userData.user.name);
+      formik.setFieldValue('description', userData.user.description);
+    }
+    // Ignored since the suggested fix broke the react hooks lifecycle
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [userData]);
 
   /**
    * Handles image file uploads
@@ -28,30 +82,7 @@ const EditProfile = () => {
     formik.setFieldValue('imageFile', event.target.files[0]);
   };
 
-  const formik = useFormik<IProfileEditForm>({
-    initialValues: {
-      displayName: '',
-      description: '',
-      imageFile: null,
-    },
-
-    validationSchema: Yup.object({
-      displayName: Yup.string().required('Display name is required'),
-      description: Yup.string().required('Description is required'),
-    }),
-    //TODO: implement form logic
-    onSubmit: async () => {
-      const errors = await formik.validateForm();
-      if (isEmpty(errors)) {
-        //TODO: update profile in database
-        console.log('Form successfully submitted');
-      } else {
-        formik.setTouched(setNestedObjectValues<FormikTouched<FormikValues>>(errors, true));
-      }
-    },
-  });
-
-  return (
+  return !userLoading && userData ? (
     <div className="page-container">
       <MullBackButton>Profile</MullBackButton>
       <form className="edit-profile-container" onSubmit={formik.handleSubmit}>
@@ -99,6 +130,8 @@ const EditProfile = () => {
         </MullButton>
       </form>
     </div>
+  ) : (
+    <div className="page-container">Loading...</div>
   );
 };
 

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
@@ -32,7 +32,10 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
       imageFile: '',
     },
     validationSchema: Yup.object({
-      displayName: Yup.string().required('Display name is required'),
+      displayName: Yup.string()
+        .required('Display name is required')
+        .max(24, 'Display Name must be 24 characters or less.'),
+      description: Yup.string().max(250, 'Description must be 250 characters or less.'),
     }),
 
     onSubmit: async () => {

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
@@ -1,7 +1,6 @@
 import { IProfileEditForm } from '@mull/types';
-import { FormikTouched, FormikValues, setNestedObjectValues, useFormik } from 'formik';
+import { useFormik } from 'formik';
 import { History } from 'history';
-import { isEmpty } from 'lodash';
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import * as Yup from 'yup';
@@ -39,28 +38,23 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
     }),
 
     onSubmit: async () => {
-      const errors = await formik.validateForm();
-      if (isEmpty(errors)) {
-        notifyToast('Submitting User Profile...');
-        try {
-          await updateUser({
-            variables: {
-              newAvatar: file,
-              userInput: {
-                id: userData.user.id,
-                name: formik.values.displayName,
-                description: formik.values.description,
-              },
+      notifyToast('Submitting User Profile...');
+      try {
+        await updateUser({
+          variables: {
+            newAvatar: file,
+            userInput: {
+              id: userData.user.id,
+              name: formik.values.displayName,
+              description: formik.values.description,
             },
-          });
-          updateToast(toast.TYPE.SUCCESS, 'Profile Updated');
-          history.push(ROUTES.PROFILE.DISPLAY);
-        } catch (err) {
-          updateToast(toast.TYPE.ERROR, 'Error: Failed To Update Profile');
-          console.error(err);
-        }
-      } else {
-        formik.setTouched(setNestedObjectValues<FormikTouched<FormikValues>>(errors, true));
+          },
+        });
+        updateToast(toast.TYPE.SUCCESS, 'Profile Updated');
+        history.push(ROUTES.PROFILE.DISPLAY);
+      } catch (err) {
+        updateToast(toast.TYPE.ERROR, 'Error: Failed To Update Profile');
+        console.error(err);
       }
     },
   });
@@ -75,6 +69,8 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [userData]);
 
+  if (userLoading) return <div className="page-container">Loading...</div>;
+
   /**
    * Handles image file uploads
    * @param {ChangeEvent<HTMLInputElement>} event
@@ -85,7 +81,7 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
     formik.setFieldValue('imageFile', event.target.files[0]);
   };
 
-  return !userLoading && userData ? (
+  return (
     <div className="page-container">
       <MullBackButton>Profile</MullBackButton>
       <form className="edit-profile-container" onSubmit={formik.handleSubmit}>
@@ -133,8 +129,6 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
         </MullButton>
       </form>
     </div>
-  ) : (
-    <div className="page-container">Loading...</div>
   );
 };
 

--- a/apps/mull-ui/src/app/pages/profile/user-profile/__snapshots__/user-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/__snapshots__/user-profile.spec.tsx.snap
@@ -10,8 +10,10 @@ exports[`UserProfilePage should match snapshot 1`] = `
     <div
       className="user-name-container"
     >
-      <h1>
-        Andrea Gloria
+      <h1
+        data-testid="userName"
+      >
+        Jane Doe
       </h1>
       <button
         className="share-button"
@@ -41,29 +43,32 @@ exports[`UserProfilePage should match snapshot 1`] = `
       <img
         alt="user"
         className="user-profile-picture"
-        src="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
+        src="./assets/icons/icon-192x192.png"
       />
       <div
         className="profile-side-container for-current-user"
       >
         <button
           className="profile-stats"
+          data-testid="portfolioCount"
         >
-          8
+          0
           <br />
           Portfolio
         </button>
         <button
           className="profile-stats"
+          data-testid="friendCount"
         >
-          24
+          0
           <br />
           Friends
         </button>
         <button
           className="profile-stats"
+          data-testid="hostingCount"
         >
-          2
+          1
           <br />
           Hosting
         </button>
@@ -72,8 +77,10 @@ exports[`UserProfilePage should match snapshot 1`] = `
     <div
       className="user-description-container"
     >
-      <p>
-        Regardless of making complicated reasons or calculations, I just want to live simply counting up to about 5 or 6.
+      <p
+        data-testid="userDescription"
+      >
+        a description
       </p>
     </div>
   </div>
@@ -233,7 +240,11 @@ exports[`UserProfilePage should match snapshot 1`] = `
   >
     <p>
       Joined Müll on 
-      February 2, 2021
+      February
+       
+      19
+      , 
+      2021
     </p>
   </div>
 </div>

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.spec.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.spec.tsx
@@ -1,28 +1,63 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import renderer from 'react-test-renderer';
+import { Router } from 'react-router-dom';
+import renderer, { act } from 'react-test-renderer';
+import { ROUTES } from '../../../../constants';
+import { UserProfileDocument, UserProfileQuery } from '../../../../generated/graphql';
+import { UserProvider } from '../../../context/user.context';
 import UserProfilePage from './user-profile';
 
 describe('UserProfilePage', () => {
-  it('should render successfully', () => {
-    const { baseElement } = render(
-      <BrowserRouter>
-        <UserProfilePage />
-      </BrowserRouter>
+  const renderHelper = (history, mocks: MockedResponse[]) => {
+    return (
+      <UserProvider value={{ userId: 1, setUserId: jest.fn() }}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <UserProfilePage />
+          </Router>
+        </MockedProvider>
+      </UserProvider>
     );
+  };
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+    history.push(ROUTES.PROFILE.DISPLAY);
 
+    const { baseElement } = render(renderHelper(history, null));
     expect(baseElement).toBeTruthy();
   });
 
-  it('should match snapshot', () => {
-    const tree = renderer
-      .create(
-        <BrowserRouter>
-          <UserProfilePage />
-        </BrowserRouter>
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+  it('should match snapshot', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UserProfileDocument,
+        },
+        result: {
+          data: {
+            user: {
+              id: 1,
+              name: 'Jane Doe',
+              description: 'a description',
+              avatar: null,
+              joinDate: '2021-02-19T14:46:13.000Z',
+            },
+            friendCount: 0,
+            hostingCount: 1,
+            portfolioCount: 0,
+          } as UserProfileQuery,
+        },
+      },
+    ];
+
+    const history = createMemoryHistory();
+    history.push(ROUTES.PROFILE.DISPLAY);
+    await act(async () => {
+      const tree = renderer.create(renderHelper(history, mocks));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(tree.toJSON()).toMatchSnapshot();
+    });
   });
 });

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
@@ -26,9 +26,9 @@ export const UserProfilePage = () => {
           userName={userProfile.user.name}
           userPicture={avatarUrl(userProfile.user as User)}
           userDescription={userProfile.user.description}
-          userPortfolio={userProfile.portfolioCount}
-          userFriends={userProfile.friendCount}
-          userHosting={userProfile.hostingCount}
+          portfolioCount={userProfile.portfolioCount}
+          friendCount={userProfile.friendCount}
+          hostingCount={userProfile.hostingCount}
         />
         <div className="settings-container">
           <h3>Portfolio</h3>

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
@@ -16,47 +16,45 @@ import './user-profile.scss';
 export const UserProfilePage = () => {
   const { data: userProfile, loading } = useUserProfileQuery();
 
-  if (!loading && userProfile) {
-    const { year, month, day } = formatJoinDate(new Date(userProfile.user.joinDate));
-    const friendRequestExists = true;
+  if (loading) return <div className="page-container">Loading...</div>;
 
-    return (
-      <div className="page-container">
-        <ProfileHeader
-          userName={userProfile.user.name}
-          userPicture={avatarUrl(userProfile.user as User)}
-          userDescription={userProfile.user.description}
-          portfolioCount={userProfile.portfolioCount}
-          friendCount={userProfile.friendCount}
-          hostingCount={userProfile.hostingCount}
-        />
-        <div className="settings-container">
-          <h3>Portfolio</h3>
-          <SettingsButton icon={faLeaf} settingName="My Portfolio" />
-        </div>
-        <div className="settings-container with-friends">
-          <h3>Friends</h3>
-          <SettingsButton icon={faUserPlus} settingName="Add Friends" />
-          <SettingsButton icon={faUserFriends} settingName="My Friends" />
-          <p className={friendRequestExists ? 'friend-request-count' : 'no-friend-request'}>{4}</p>
-        </div>
-        <div className="settings-container below-friends">
-          <h3>Misc.</h3>
-          <Link to="/profile/edit">
-            <SettingsButton icon={faPencilAlt} settingName="Edit Profile" />
-          </Link>
-          <SettingsButton icon={faCog} settingName="Settings" />
-        </div>
-        <div className="joined-date-container">
-          <p>
-            Joined Müll on {month} {day}, {year}
-          </p>
-        </div>
+  const { year, month, day } = formatJoinDate(new Date(userProfile.user.joinDate));
+  const friendRequestExists = true;
+
+  return (
+    <div className="page-container">
+      <ProfileHeader
+        userName={userProfile.user.name}
+        userPicture={avatarUrl(userProfile.user as User)}
+        userDescription={userProfile.user.description}
+        portfolioCount={userProfile.portfolioCount}
+        friendCount={userProfile.friendCount}
+        hostingCount={userProfile.hostingCount}
+      />
+      <div className="settings-container">
+        <h3>Portfolio</h3>
+        <SettingsButton icon={faLeaf} settingName="My Portfolio" />
       </div>
-    );
-  } else {
-    return <div className="page-container">Loading...</div>;
-  }
+      <div className="settings-container with-friends">
+        <h3>Friends</h3>
+        <SettingsButton icon={faUserPlus} settingName="Add Friends" />
+        <SettingsButton icon={faUserFriends} settingName="My Friends" />
+        <p className={friendRequestExists ? 'friend-request-count' : 'no-friend-request'}>{4}</p>
+      </div>
+      <div className="settings-container below-friends">
+        <h3>Misc.</h3>
+        <Link to="/profile/edit">
+          <SettingsButton icon={faPencilAlt} settingName="Edit Profile" />
+        </Link>
+        <SettingsButton icon={faCog} settingName="Settings" />
+      </div>
+      <div className="joined-date-container">
+        <p>
+          Joined Müll on {month} {day}, {year}
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default UserProfilePage;

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
@@ -7,50 +7,56 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { User, useUserProfileQuery } from '../../../../generated/graphql';
+import { avatarUrl, formatJoinDate } from '../../../../utilities';
 import ProfileHeader from '../../../components/profile-header/profile-header';
 import SettingsButton from '../../../components/settings-button/settings-button';
 import './user-profile.scss';
 
-export interface userProfileProps {
-  joinDate?: string;
-  friendRequestCount?: number;
-}
+export const UserProfilePage = () => {
+  const { data: userProfile, loading } = useUserProfileQuery();
 
-export const UserProfilePage = ({ joinDate, friendRequestCount }: userProfileProps) => {
-  const friendRequestExists = true;
-  return (
-    <div className="page-container">
-      <ProfileHeader
-        userName="Andrea Gloria"
-        userPicture="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-        userPortfolio={8}
-        userFriends={24}
-        userHosting={2}
-        userDescription="Regardless of making complicated reasons or calculations, I just want to live simply counting up to about 5 or 6."
-      />
-      <div className="settings-container">
-        <h3>Portfolio</h3>
-        <SettingsButton icon={faLeaf} settingName="My Portfolio" />
+  if (!loading && userProfile) {
+    var { year, month, day } = formatJoinDate(new Date(userProfile.user.joinDate));
+    const friendRequestExists = true;
+
+    return (
+      <div className="page-container">
+        <ProfileHeader
+          userName={userProfile.user.name}
+          userPicture={avatarUrl(userProfile.user as User)}
+          userDescription={userProfile.user.description}
+          userPortfolio={userProfile.portfolioCount}
+          userFriends={userProfile.friendCount}
+          userHosting={userProfile.hostingCount}
+        />
+        <div className="settings-container">
+          <h3>Portfolio</h3>
+          <SettingsButton icon={faLeaf} settingName="My Portfolio" />
+        </div>
+        <div className="settings-container with-friends">
+          <h3>Friends</h3>
+          <SettingsButton icon={faUserPlus} settingName="Add Friends" />
+          <SettingsButton icon={faUserFriends} settingName="My Friends" />
+          <p className={friendRequestExists ? 'friend-request-count' : 'no-friend-request'}>{4}</p>
+        </div>
+        <div className="settings-container below-friends">
+          <h3>Misc.</h3>
+          <Link to="/profile/edit">
+            <SettingsButton icon={faPencilAlt} settingName="Edit Profile" />
+          </Link>
+          <SettingsButton icon={faCog} settingName="Settings" />
+        </div>
+        <div className="joined-date-container">
+          <p>
+            Joined Müll on {month} {day}, {year}
+          </p>
+        </div>
       </div>
-      <div className="settings-container with-friends">
-        <h3>Friends</h3>
-        <SettingsButton icon={faUserPlus} settingName="Add Friends" />
-        <SettingsButton icon={faUserFriends} settingName="My Friends" />
-        <p className={friendRequestExists ? 'friend-request-count' : 'no-friend-request'}>
-          {(friendRequestCount = 4)}
-        </p>
-      </div>
-      <div className="settings-container below-friends">
-        <h3>Misc.</h3>
-        <Link to="/profile/edit">
-          <SettingsButton icon={faPencilAlt} settingName="Edit Profile" />
-        </Link>
-        <SettingsButton icon={faCog} settingName="Settings" />
-      </div>
-      <div className="joined-date-container">
-        <p>Joined Müll on {(joinDate = 'February 2, 2021')}</p>
-      </div>
-    </div>
-  );
+    );
+  } else {
+    return <div className="page-container">Loading...</div>;
+  }
 };
+
 export default UserProfilePage;

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
@@ -17,7 +17,7 @@ export const UserProfilePage = () => {
   const { data: userProfile, loading } = useUserProfileQuery();
 
   if (!loading && userProfile) {
-    var { year, month, day } = formatJoinDate(new Date(userProfile.user.joinDate));
+    const { year, month, day } = formatJoinDate(new Date(userProfile.user.joinDate));
     const friendRequestExists = true;
 
     return (

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -407,6 +407,20 @@ export type LeaveEventMutation = (
   & Pick<Mutation, 'leaveEvent'>
 );
 
+export type UpdateUserMutationVariables = Exact<{
+  userInput: UpdateUserInput;
+  newAvatar?: Maybe<Scalars['Upload']>;
+}>;
+
+
+export type UpdateUserMutation = (
+  { __typename?: 'Mutation' }
+  & { updateUser: (
+    { __typename?: 'User' }
+    & Pick<User, 'id'>
+  ) }
+);
+
 export type EventPageContentFragment = (
   { __typename?: 'Event' }
   & Pick<Event, 'id' | 'title' | 'description' | 'startDate' | 'endDate' | 'restriction'>
@@ -431,6 +445,15 @@ export type EventCardContentFragment = (
   )>, image?: Maybe<(
     { __typename?: 'Media' }
     & Pick<Media, 'id' | 'mediaType'>
+  )> }
+);
+
+export type UserContentFragment = (
+  { __typename?: 'User' }
+  & Pick<User, 'id' | 'name' | 'description'>
+  & { avatar?: Maybe<(
+    { __typename?: 'Media' }
+    & Pick<Media, 'id'>
   )> }
 );
 
@@ -491,7 +514,20 @@ export type UserQuery = (
   { __typename?: 'Query' }
   & { user: (
     { __typename?: 'User' }
-    & Pick<User, 'id' | 'name'>
+    & UserContentFragment
+  ) }
+);
+
+export type UserProfileQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type UserProfileQuery = (
+  { __typename?: 'Query' }
+  & Pick<Query, 'friendCount' | 'hostingCount' | 'portfolioCount'>
+  & { user: (
+    { __typename?: 'User' }
+    & Pick<User, 'joinDate'>
+    & UserContentFragment
   ) }
 );
 
@@ -539,6 +575,16 @@ export const EventCardContentFragmentDoc = gql`
   image {
     id
     mediaType
+  }
+}
+    `;
+export const UserContentFragmentDoc = gql`
+    fragment UserContent on User {
+  id
+  name
+  description
+  avatar {
+    id
   }
 }
     `;
@@ -731,6 +777,39 @@ export function useLeaveEventMutation(baseOptions?: Apollo.MutationHookOptions<L
 export type LeaveEventMutationHookResult = ReturnType<typeof useLeaveEventMutation>;
 export type LeaveEventMutationResult = Apollo.MutationResult<LeaveEventMutation>;
 export type LeaveEventMutationOptions = Apollo.BaseMutationOptions<LeaveEventMutation, LeaveEventMutationVariables>;
+export const UpdateUserDocument = gql`
+    mutation UpdateUser($userInput: UpdateUserInput!, $newAvatar: Upload) {
+  updateUser(userInput: $userInput, newAvatar: $newAvatar) {
+    id
+  }
+}
+    `;
+export type UpdateUserMutationFn = Apollo.MutationFunction<UpdateUserMutation, UpdateUserMutationVariables>;
+
+/**
+ * __useUpdateUserMutation__
+ *
+ * To run a mutation, you first call `useUpdateUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateUserMutation, { data, loading, error }] = useUpdateUserMutation({
+ *   variables: {
+ *      userInput: // value for 'userInput'
+ *      newAvatar: // value for 'newAvatar'
+ *   },
+ * });
+ */
+export function useUpdateUserMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserMutation, UpdateUserMutationVariables>) {
+        return Apollo.useMutation<UpdateUserMutation, UpdateUserMutationVariables>(UpdateUserDocument, baseOptions);
+      }
+export type UpdateUserMutationHookResult = ReturnType<typeof useUpdateUserMutation>;
+export type UpdateUserMutationResult = Apollo.MutationResult<UpdateUserMutation>;
+export type UpdateUserMutationOptions = Apollo.BaseMutationOptions<UpdateUserMutation, UpdateUserMutationVariables>;
 export const DiscoverEventsDocument = gql`
     query DiscoverEvents {
   discoverEvents {
@@ -867,11 +946,10 @@ export type EventPageQueryResult = Apollo.QueryResult<EventPageQuery, EventPageQ
 export const UserDocument = gql`
     query User {
   user {
-    id
-    name
+    ...UserContent
   }
 }
-    `;
+    ${UserContentFragmentDoc}`;
 
 /**
  * __useUserQuery__
@@ -897,33 +975,39 @@ export function useUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserQ
 export type UserQueryHookResult = ReturnType<typeof useUserQuery>;
 export type UserLazyQueryHookResult = ReturnType<typeof useUserLazyQuery>;
 export type UserQueryResult = Apollo.QueryResult<UserQuery, UserQueryVariables>;
-export const PostAddedDocument = gql`
-    subscription PostAdded {
-  postAdded {
-    message
-    createdTime
-    id
+export const UserProfileDocument = gql`
+    query UserProfile {
+  user {
+    ...UserContent
+    joinDate
   }
+  friendCount
+  hostingCount
+  portfolioCount
 }
-    `;
+    ${UserContentFragmentDoc}`;
 
 /**
- * __usePostAddedSubscription__
+ * __useUserProfileQuery__
  *
- * To run a query within a React component, call `usePostAddedSubscription` and pass it any options that fit your needs.
- * When your component renders, `usePostAddedSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserProfileQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserProfileQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
- * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePostAddedSubscription({
+ * const { data, loading, error } = useUserProfileQuery({
  *   variables: {
  *   },
  * });
  */
-export function usePostAddedSubscription(baseOptions?: Apollo.SubscriptionHookOptions<PostAddedSubscription, PostAddedSubscriptionVariables>) {
-        return Apollo.useSubscription<PostAddedSubscription, PostAddedSubscriptionVariables>(PostAddedDocument, baseOptions);
+export function useUserProfileQuery(baseOptions?: Apollo.QueryHookOptions<UserProfileQuery, UserProfileQueryVariables>) {
+        return Apollo.useQuery<UserProfileQuery, UserProfileQueryVariables>(UserProfileDocument, baseOptions);
       }
-export type PostAddedSubscriptionHookResult = ReturnType<typeof usePostAddedSubscription>;
-export type PostAddedSubscriptionResult = Apollo.SubscriptionResult<PostAddedSubscription>;
+export function useUserProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserProfileQuery, UserProfileQueryVariables>) {
+          return Apollo.useLazyQuery<UserProfileQuery, UserProfileQueryVariables>(UserProfileDocument, baseOptions);
+        }
+export type UserProfileQueryHookResult = ReturnType<typeof useUserProfileQuery>;
+export type UserProfileLazyQueryHookResult = ReturnType<typeof useUserProfileLazyQuery>;
+export type UserProfileQueryResult = Apollo.QueryResult<UserProfileQuery, UserProfileQueryVariables>;

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -448,15 +448,6 @@ export type EventCardContentFragment = (
   )> }
 );
 
-export type UserContentFragment = (
-  { __typename?: 'User' }
-  & Pick<User, 'id' | 'name' | 'description'>
-  & { avatar?: Maybe<(
-    { __typename?: 'Media' }
-    & Pick<Media, 'id'>
-  )> }
-);
-
 export type DiscoverEventsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -514,7 +505,11 @@ export type UserQuery = (
   { __typename?: 'Query' }
   & { user: (
     { __typename?: 'User' }
-    & UserContentFragment
+    & Pick<User, 'id' | 'name' | 'description'>
+    & { avatar?: Maybe<(
+      { __typename?: 'Media' }
+      & Pick<Media, 'id'>
+    )> }
   ) }
 );
 
@@ -526,8 +521,11 @@ export type UserProfileQuery = (
   & Pick<Query, 'friendCount' | 'hostingCount' | 'portfolioCount'>
   & { user: (
     { __typename?: 'User' }
-    & Pick<User, 'joinDate'>
-    & UserContentFragment
+    & Pick<User, 'name' | 'description' | 'joinDate'>
+    & { avatar?: Maybe<(
+      { __typename?: 'Media' }
+      & Pick<Media, 'id'>
+    )> }
   ) }
 );
 
@@ -575,16 +573,6 @@ export const EventCardContentFragmentDoc = gql`
   image {
     id
     mediaType
-  }
-}
-    `;
-export const UserContentFragmentDoc = gql`
-    fragment UserContent on User {
-  id
-  name
-  description
-  avatar {
-    id
   }
 }
     `;
@@ -946,10 +934,15 @@ export type EventPageQueryResult = Apollo.QueryResult<EventPageQuery, EventPageQ
 export const UserDocument = gql`
     query User {
   user {
-    ...UserContent
+    id
+    name
+    description
+    avatar {
+      id
+    }
   }
 }
-    ${UserContentFragmentDoc}`;
+    `;
 
 /**
  * __useUserQuery__
@@ -978,14 +971,18 @@ export type UserQueryResult = Apollo.QueryResult<UserQuery, UserQueryVariables>;
 export const UserProfileDocument = gql`
     query UserProfile {
   user {
-    ...UserContent
+    name
+    description
     joinDate
+    avatar {
+      id
+    }
   }
   friendCount
   hostingCount
   portfolioCount
 }
-    ${UserContentFragmentDoc}`;
+    `;
 
 /**
  * __useUserProfileQuery__

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -19,7 +19,7 @@ export type Scalars = {
 
 export type Channel = {
   __typename?: 'Channel';
-  event: Event;
+  event?: Maybe<Event>;
   id: Scalars['Int'];
   name: Scalars['String'];
   participants: Array<User>;
@@ -29,6 +29,11 @@ export type Channel = {
 
 export type ChannelInput = {
   id: Scalars['Float'];
+};
+
+export type CreateChannelInput = {
+  name: Scalars['String'];
+  rights: Scalars['Float'];
 };
 
 export type CreateEventInput = {
@@ -42,7 +47,7 @@ export type CreateEventInput = {
 };
 
 export type CreatePostInput = {
-  channel?: Maybe<ChannelInput>;
+  channel: ChannelInput;
   createdTime: Scalars['DateTime'];
   medias?: Maybe<MediaInput>;
   message: Scalars['String'];
@@ -111,9 +116,11 @@ export type MediaInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  createChannel: Scalars['Boolean'];
   createEvent: Event;
   createLocation: Location;
   createUser: User;
+  deleteChannel: Scalars['Boolean'];
   deleteEvent: Event;
   deletePost: Post;
   deleteUser: User;
@@ -129,6 +136,12 @@ export type Mutation = {
 };
 
 
+export type MutationCreateChannelArgs = {
+  eventId: Scalars['Int'];
+  input: CreateChannelInput;
+};
+
+
 export type MutationCreateEventArgs = {
   event: CreateEventInput;
 };
@@ -141,6 +154,11 @@ export type MutationCreateLocationArgs = {
 
 export type MutationCreateUserArgs = {
   user: CreateUserInput;
+};
+
+
+export type MutationDeleteChannelArgs = {
+  id: Scalars['Int'];
 };
 
 
@@ -242,11 +260,13 @@ export type PostReactionInput = {
 
 export type Query = {
   __typename?: 'Query';
+  channelPosts: Array<Post>;
   coHostEvents: Array<Event>;
   discoverEvents: Array<Event>;
   event: Event;
   events: Array<Event>;
   friendCount: Scalars['Int'];
+  getChannel: Channel;
   hostEvents: Array<Event>;
   hostingCount: Scalars['Int'];
   isParticipant: Scalars['Boolean'];
@@ -259,7 +279,17 @@ export type Query = {
 };
 
 
+export type QueryChannelPostsArgs = {
+  channelId: Scalars['Int'];
+};
+
+
 export type QueryEventArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryGetChannelArgs = {
   id: Scalars['Int'];
 };
 
@@ -285,6 +315,11 @@ export type Subscription = {
   postAdded: Post;
 };
 
+
+export type SubscriptionPostAddedArgs = {
+  channelId: Scalars['Int'];
+};
+
 export type UpdateEventInput = {
   description?: Maybe<Scalars['String']>;
   endDate?: Maybe<Scalars['DateTime']>;
@@ -296,7 +331,7 @@ export type UpdateEventInput = {
 };
 
 export type UpdatePostInput = {
-  channel?: Maybe<ChannelInput>;
+  channel: ChannelInput;
   createdTime: Scalars['DateTime'];
   id: Scalars['Int'];
   medias?: Maybe<MediaInput>;
@@ -529,7 +564,9 @@ export type UserProfileQuery = (
   ) }
 );
 
-export type PostAddedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+export type PostAddedSubscriptionVariables = Exact<{
+  channelId: Scalars['Int'];
+}>;
 
 
 export type PostAddedSubscription = (
@@ -1008,3 +1045,34 @@ export function useUserProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOption
 export type UserProfileQueryHookResult = ReturnType<typeof useUserProfileQuery>;
 export type UserProfileLazyQueryHookResult = ReturnType<typeof useUserProfileLazyQuery>;
 export type UserProfileQueryResult = Apollo.QueryResult<UserProfileQuery, UserProfileQueryVariables>;
+export const PostAddedDocument = gql`
+    subscription PostAdded($channelId: Int!) {
+  postAdded(channelId: $channelId) {
+    message
+    createdTime
+    id
+  }
+}
+    `;
+
+/**
+ * __usePostAddedSubscription__
+ *
+ * To run a query within a React component, call `usePostAddedSubscription` and pass it any options that fit your needs.
+ * When your component renders, `usePostAddedSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePostAddedSubscription({
+ *   variables: {
+ *      channelId: // value for 'channelId'
+ *   },
+ * });
+ */
+export function usePostAddedSubscription(baseOptions: Apollo.SubscriptionHookOptions<PostAddedSubscription, PostAddedSubscriptionVariables>) {
+        return Apollo.useSubscription<PostAddedSubscription, PostAddedSubscriptionVariables>(PostAddedDocument, baseOptions);
+      }
+export type PostAddedSubscriptionHookResult = ReturnType<typeof usePostAddedSubscription>;
+export type PostAddedSubscriptionResult = Apollo.SubscriptionResult<PostAddedSubscription>;

--- a/apps/mull-ui/src/graphql/mutations.gql
+++ b/apps/mull-ui/src/graphql/mutations.gql
@@ -36,3 +36,9 @@ mutation JoinEvent($eventId: Int!) {
 mutation LeaveEvent($eventId: Int!) {
   leaveEvent(eventId: $eventId)
 }
+
+mutation UpdateUser($userInput: UpdateUserInput!, $newAvatar: Upload) {
+  updateUser(userInput: $userInput, newAvatar: $newAvatar) {
+    id
+  }
+}

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -32,15 +32,6 @@ fragment EventCardContent on Event {
   }
 }
 
-fragment UserContent on User {
-  id
-  name
-  description
-  avatar {
-    id
-  }
-}
-
 query DiscoverEvents {
   discoverEvents {
     ...EventCardContent
@@ -75,14 +66,23 @@ query EventPage($eventId: Int!) {
 
 query User {
   user {
-    ...UserContent
+    id
+    name
+    description
+    avatar {
+      id
+    }
   }
 }
 
 query UserProfile {
   user {
-    ...UserContent
+    name
+    description
     joinDate
+    avatar {
+      id
+    }
   }
 
   friendCount

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -32,6 +32,15 @@ fragment EventCardContent on Event {
   }
 }
 
+fragment UserContent on User {
+  id
+  name
+  description
+  avatar {
+    id
+  }
+}
+
 query DiscoverEvents {
   discoverEvents {
     ...EventCardContent
@@ -66,7 +75,17 @@ query EventPage($eventId: Int!) {
 
 query User {
   user {
-    id
-    name
+    ...UserContent
   }
+}
+
+query UserProfile {
+  user {
+    ...UserContent
+    joinDate
+  }
+
+  friendCount
+  hostingCount
+  portfolioCount
 }

--- a/apps/mull-ui/src/graphql/subscriptions.gql
+++ b/apps/mull-ui/src/graphql/subscriptions.gql
@@ -1,5 +1,5 @@
-subscription PostAdded {
-  postAdded {
+subscription PostAdded($channelId: Int!) {
+  postAdded(channelId: $channelId) {
     message
     createdTime
     id

--- a/apps/mull-ui/src/utilities.ts
+++ b/apps/mull-ui/src/utilities.ts
@@ -1,6 +1,7 @@
 import { DetectionResult, ISerializedEvent } from '@mull/types';
 import { categoryMap, WasteType } from './app/services/maps';
 import { environment } from './environments/environment';
+import { User } from './generated/graphql';
 
 /**
  * Converts date to a list of tokens for displaying
@@ -21,6 +22,14 @@ export const formatDate = (
   return { year: date.getFullYear(), month, day: date.getDate(), time: timeString };
 };
 
+export const formatJoinDate = (date: Date): { year: number; month: string; day: number } => {
+  const month = Intl.DateTimeFormat('en-us', {
+    month: 'long',
+  }).format(date);
+
+  return { year: date.getFullYear(), month, day: date.getDate() };
+};
+
 export const mediaUrl = (event: Partial<ISerializedEvent>) =>
   `${environment.backendUrl}/api/media/${event.image.id}`;
 
@@ -31,6 +40,11 @@ const svgMap = {
   [WasteType.TRASH]: './assets/icons/trash-recognition-icons/TrashIcon.svg',
   [WasteType.RECYCLABLE]: './assets/icons/trash-recognition-icons/RecycleIcon.svg',
 };
+
+export const avatarUrl = (user: User) =>
+  user.avatar
+    ? `${environment.backendUrl}/api/media/${user.avatar.id}`
+    : `./assets/icons/icon-192x192.png`;
 
 export const drawDetectionIcons = async (
   ctx: CanvasRenderingContext2D,


### PR DESCRIPTION
This PR closes #31 

**To Test**
1. `nx serve mull-ui` and `nx serve mull-api`
2. Create a user
3. Head to http://localhost:4200/profile to see their profile
4. Click on `Edit Profile` to make further changes to your user's profile

**Notes**
- You may have seen that at first the GQL queries used fragments and I had to revert them in my frontend testing commit. This is due to the fact that MockedProvider was not able to correctly mock data that came from fragments.
- You will see `await new Promise(resolve => setTimeout(resolve, 0));` in the frontend tests, and that is the correct way to test the success state of a MockedProvider [according to the docs](https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-success-state) as the default is `loading: true`.