### PR TITLE
Fix: Post Mutation Authentication

### DIFF
--- a/apps/mull-api/src/app/post/inputs/post.input.ts
+++ b/apps/mull-api/src/app/post/inputs/post.input.ts
@@ -2,15 +2,11 @@ import { Field, InputType, Int } from '@nestjs/graphql';
 import { ChannelInput } from '../../channel/inputs/channel.input';
 import { Media } from '../../entities';
 import { MediaInput } from '../../media/inputs/media.input';
-import { UserInput } from '../../user/inputs/user.input';
 import { ParentPostInput } from './parent-post.input';
 import { PostReactionInput } from './post-reaction.input';
 
 @InputType()
 export class CreatePostInput {
-  @Field(/* istanbul ignore next */ () => UserInput)
-  user: UserInput;
-
   @Field()
   message: string;
 

--- a/apps/mull-api/src/app/post/post.mockdata.ts
+++ b/apps/mull-api/src/app/post/post.mockdata.ts
@@ -8,7 +8,6 @@ const userC = mockAllUsers[2]; // id: 3
 
 export const mockPartialPosts: CreatePostInput | UpdatePostInput = {
   id: 22,
-  user: { id: 23 },
   message: 'This is a post',
   createdTime: new Date('2020-10-27T01:31:00.000Z'),
   channel: { id: 2 },

--- a/apps/mull-api/src/app/post/post.resolver.spec.ts
+++ b/apps/mull-api/src/app/post/post.resolver.spec.ts
@@ -43,7 +43,7 @@ describe('PostResolver', () => {
   });
 
   it('it should subscribe to new messages', async () => {
-    await resolver.post(mockPartialPosts as CreatePostInput);
+    await resolver.post(mockPartialPosts, 5);
     expect(pubSub.publish).toHaveBeenCalled();
   });
 

--- a/apps/mull-api/src/app/post/post.resolver.ts
+++ b/apps/mull-api/src/app/post/post.resolver.ts
@@ -1,6 +1,6 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
-import { AuthGuard } from '../auth/auth.guard';
+import { AuthenticatedUser, AuthGuard } from '../auth/auth.guard';
 import { Post } from '../entities';
 import { CreatePostInput, UpdatePostInput } from './inputs/post.input';
 import pubSub from './post.pubsub';
@@ -15,9 +15,8 @@ export class PostResolver {
   }
 
   @Mutation(/* istanbul ignore next */ () => Post)
-  @UseGuards(AuthGuard)
-  async post(@Args('post') post: CreatePostInput) {
-    const savedPost = this.postService.createPost(post);
+  async post(@Args('post') post: CreatePostInput, @AuthenticatedUser() userId: number) {
+    const savedPost = this.postService.createPost(post, userId);
     pubSub.publish('postAdded' + post.channel.id, {
       postAdded: savedPost,
     });

--- a/apps/mull-api/src/app/post/post.service.spec.ts
+++ b/apps/mull-api/src/app/post/post.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Post } from '../entities';
-import { CreatePostInput } from './inputs/post.input';
 import { mockAllPosts, mockPartialPosts } from './post.mockdata';
 import { PostService } from './post.service';
 
@@ -38,8 +37,8 @@ describe('PostService', () => {
   });
 
   it('should create the post', async () => {
-    const returnedPost = await service.createPost(mockPartialPosts as CreatePostInput);
-    expect(returnedPost).toEqual(returnedPost);
+    const returnedPost = await service.createPost(mockPartialPosts, 5);
+    expect(returnedPost).toEqual({ ...mockPartialPosts, user: { id: 5 } });
   });
 
   it('should fetch all posts', async () => {

--- a/apps/mull-api/src/app/post/post.service.ts
+++ b/apps/mull-api/src/app/post/post.service.ts
@@ -23,8 +23,8 @@ export class PostService {
     return this.postRepository.find({ where: { channel: { id: channelId } } });
   }
 
-  async createPost(input: CreatePostInput): Promise<Post> {
-    return this.postRepository.save(input);
+  async createPost(input: CreatePostInput, userId: number): Promise<Post> {
+    return this.postRepository.save({ ...input, user: { id: userId } });
   }
 
   async deletePost(postId: number): Promise<Post> {

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -37,7 +37,6 @@ input CreatePostInput {
   message: String!
   parentPost: ParentPostInput
   reactions: PostReactionInput
-  user: UserInput!
 }
 
 input CreateUserInput {
@@ -203,7 +202,6 @@ input UpdatePostInput {
   message: String!
   parentPost: ParentPostInput
   reactions: PostReactionInput
-  user: UserInput!
 }
 
 input UpdateUserInput {
@@ -230,8 +228,4 @@ type User {
   password: String
   registrationMethod: RegistrationMethod!
   timezone: String!
-}
-
-input UserInput {
-  id: Int!
 }


### PR DESCRIPTION
This PR fixes the `post` mutation by replacing the `Authguard` with `AuthenticatedUser` param decorator. This means we don't have to pass a `userId` explicitly when calling the mutation, increasing security and making it consistent with the rest of our mutations that havea userId param.

This mutation will be used by #156, #185, and #227. I made this PR so that those user stories can use the fixed mutation and be consistent.

**To Test**
Make sure you have a channel and a valid access token
```
mutation PostMutation($postPost: CreatePostInput!) {
  post(post: $postPost) {
    message
  }
}
```
```
{
  "postPost": {
    "channel": { "id": 2},
    "createdTime": "2021-02-28T16:11:00.000Z",
    "message": "Hello from group chat"
  }
}
```