### PR TITLE
US-3.2: Group Chat Page

### DIFF
--- a/apps/mull-ui-e2e/src/integration/US-3.2.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-3.2.spec.ts
@@ -1,0 +1,22 @@
+/// <reference types="Cypress" />
+import { frameSizes } from './../fixtures/frame-sizes';
+
+frameSizes.forEach((frame) => {
+  describe(`US-3.2: Group Chat Page (${frame.name} view)`, () => {
+    beforeEach(() => {
+      cy.interceptGraphQLReqs();
+      cy.viewport(frame.res[0], frame.res[1]);
+    });
+
+    it('should post messages on the group chat page', () => {
+      cy.mockRefreshRequest();
+      const date = new Date();
+      cy.visit('http://localhost:4200/messages/group-chat');
+      cy.get('.event-chat', { timeout: 5000 }).should('exist');
+      cy.get('.custom-text-input').type(`${date.toString()}{enter}`);
+      /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+      cy.wait(500); // Test was flaky with aliases
+      cy.contains(date.toString());
+    });
+  });
+});

--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -23,6 +23,7 @@ import LoginPage from './pages/login/login';
 import AnnouncementsPage from './pages/messages/announcements/announcements';
 import ChatPagesHeader from './pages/messages/chat-pages-header';
 import EventMessageList from './pages/messages/event-messages/event-message-list';
+import GroupChatPage from './pages/messages/group-chat/group-chat';
 import EditProfilePage from './pages/profile/edit-profile/edit-profile';
 import UserProfilePage from './pages/profile/user-profile/user-profile';
 import RegisterPage from './pages/register/register';
@@ -112,8 +113,7 @@ export const App = () => {
           <PrivateRoute path={ROUTES.MESSAGES}>
             <ChatPagesHeader>
               <div className="page-container with-sub-nav-and-header with-bottom-chat-input">
-                {/* TODO: Create the Group Chat page and add in its component here */}
-                {/* <PrivateRoute path={ROUTES.GROUPCHAT.url} component={GroupChatPage} /> */}
+                <PrivateRoute path={ROUTES.GROUPCHAT.url} component={GroupChatPage} />
                 <PrivateRoute path={ROUTES.ANNOUNCEMENTS.url} component={AnnouncementsPage} />
                 <PrivateRoute exact path={ROUTES.MESSAGES}>
                   <Redirect to={ROUTES.ANNOUNCEMENTS.url} />

--- a/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.spec.tsx
+++ b/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import GroupChat from './group-chat';
+
+describe('GroupChat', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<GroupChat />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.spec.tsx
+++ b/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.spec.tsx
@@ -1,11 +1,30 @@
-import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { ROUTES } from '../../../../../src/constants';
+import { UserProvider } from '../../../context/user.context';
+import GroupChatPage from './group-chat';
 
-import GroupChat from './group-chat';
+describe('GroupChatPage', () => {
+  const renderHelper = (history) => {
+    return (
+      <UserProvider value={{ userId: 1, setUserId: jest.fn() }}>
+        <MockedProvider>
+          <Router history={history}>
+            <GroupChatPage />
+          </Router>
+        </MockedProvider>
+      </UserProvider>
+    );
+  };
 
-describe('GroupChat', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<GroupChat />);
+    const history = createMemoryHistory();
+    history.push(ROUTES.MY_EVENTS.url);
+
+    const { baseElement } = render(renderHelper(history));
     expect(baseElement).toBeTruthy();
   });
 });

--- a/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/group-chat/group-chat.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import EventChat from '../event-chat/event-chat';
+
+export const GroupChatPage = () => {
+  return <EventChat eventId={1} channelName="Group Chat" restrictChatInput={false} />;
+};
+
+export default GroupChatPage;


### PR DESCRIPTION
Closes #185
Created the group chat page.

How to test: 
1. Create a user to join an event with id 1
2. Access http://localhost:4200/messages/group-chat, and you can type something and send it in the chat
3. You can create multiple users and join the event with id 1 to test this feature

![image](https://user-images.githubusercontent.com/36641869/110226275-ddcb3b80-7ebb-11eb-8a7d-d333c2ec17e6.png)

