### PR TITLE
TASK-64: messages main menu backend

### DIFF
--- a/apps/mull-api/src/app/entities/channel.entity.ts
+++ b/apps/mull-api/src/app/entities/channel.entity.ts
@@ -8,7 +8,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
-  TableInheritance
+  TableInheritance,
 } from 'typeorm';
 import { Event, Post, User } from './';
 

--- a/apps/mull-api/src/app/entities/user.entity.ts
+++ b/apps/mull-api/src/app/entities/user.entity.ts
@@ -10,10 +10,7 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Event } from './event.entity';
-import { Media } from './media.entity';
-import { PostReaction } from './post-reaction.entity';
-import { Post } from './post.entity';
+import { DirectMessageChannel, Event, Media, Post, PostReaction } from './';
 
 registerEnumType(RegistrationMethod, {
   name: 'RegistrationMethod',
@@ -103,4 +100,13 @@ export class User implements IUser {
 
   @OneToMany(/* istanbul ignore next */ () => Post, /* istanbul ignore next */ (post) => post.user)
   posts?: Post[];
+}
+
+@ObjectType()
+export class Friend extends User {
+  @Field(/* istanbul ignore next */ () => Post, { nullable: true })
+  latestPost: Post;
+
+  @Field(/* istanbul ignore next */ () => DirectMessageChannel, { nullable: true })
+  directMessageChannel: DirectMessageChannel;
 }

--- a/apps/mull-api/src/app/post/post.mockdata.ts
+++ b/apps/mull-api/src/app/post/post.mockdata.ts
@@ -59,4 +59,17 @@ export const mockAllPosts: Post[] = [
       validateReadPermission: directMessageChannel.validateReadPermission,
     },
   },
+  {
+    id: 26,
+    user: userA,
+    message: 'This the 4th post',
+    createdTime: new Date('2020-10-27T01:31:00.000Z'),
+    channel: {
+      id: 4,
+      posts: [],
+      participants: [userA, userB],
+      validateWritePermission: directMessageChannel.validateWritePermission,
+      validateReadPermission: directMessageChannel.validateReadPermission,
+    },
+  },
 ];

--- a/apps/mull-api/src/app/post/post.service.spec.ts
+++ b/apps/mull-api/src/app/post/post.service.spec.ts
@@ -106,6 +106,6 @@ describe('PostService', () => {
       getOne: jest.fn().mockReturnValue([...mockAllPosts].reverse()[0]),
     });
     const latestPost = await service.getLatestPost(mockAllPosts[0].channel.id);
-    expect(latestPost).toEqual(mockAllPosts[2]);
+    expect(latestPost).toEqual(mockAllPosts[3]);
   });
 });

--- a/apps/mull-api/src/app/post/post.service.ts
+++ b/apps/mull-api/src/app/post/post.service.ts
@@ -44,4 +44,13 @@ export class PostService {
     await this.postRepository.update(input.id, { ...input });
     return this.getPost(input.id);
   }
+
+  async getLatestPost(channelId: number): Promise<Post> {
+    return this.postRepository
+      .createQueryBuilder('post')
+      .leftJoinAndSelect('post.channel', 'channel')
+      .where('channel.id = :channelId', { channelId })
+      .orderBy('post.createdTime', 'DESC')
+      .getOne();
+  }
 }

--- a/apps/mull-api/src/app/user/friend.mockdata.ts
+++ b/apps/mull-api/src/app/user/friend.mockdata.ts
@@ -1,0 +1,38 @@
+import { RegistrationMethod } from '@mull/types';
+import { mockAllDirectMessageChannels } from '../channel/channel.mockdata';
+import { Friend } from '../entities';
+import { mockAllPosts } from '../post/post.mockdata';
+
+// Friends of mockAllUsers[0]
+export const mockAllFriends: Friend[] = [
+  {
+    id: 7,
+    password: 'password',
+    email: 'me@me.com',
+    timezone: '',
+    name: 'Cristian',
+    dob: new Date(),
+    description: "There's a first for everything",
+    friends: [],
+    tokenVersion: 0,
+    registrationMethod: RegistrationMethod.LOCAL,
+    avatar: null,
+    latestPost: mockAllPosts[3],
+    directMessageChannel: mockAllDirectMessageChannels[0],
+  },
+  {
+    id: 12,
+    password: 'abc123',
+    email: 'tim@green.co',
+    timezone: '',
+    name: 'Tim',
+    dob: new Date(),
+    description: '',
+    friends: [],
+    tokenVersion: 0,
+    registrationMethod: RegistrationMethod.LOCAL,
+    avatar: null,
+    latestPost: null,
+    directMessageChannel: null,
+  },
+];

--- a/apps/mull-api/src/app/user/user.module.ts
+++ b/apps/mull-api/src/app/user/user.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
+import { ChannelService } from '../channel/channel.service';
 import { EntitiesModule } from '../entities';
 import { EventService } from '../event/event.service';
 import { MediaService } from '../media/media.service';
+import { PostService } from '../post/post.service';
 import { UserResolver } from './user.resolver';
 import { UserService } from './user.service';
 
 @Module({
   imports: [EntitiesModule],
-  providers: [UserResolver, UserService, EventService, MediaService],
+  providers: [UserResolver, UserService, EventService, MediaService, ChannelService, PostService],
   exports: [UserService],
 })
 export class UserModule {}

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -66,6 +66,22 @@ type EventChannel {
   rights: Int!
 }
 
+type Friend {
+  avatar: Media
+  description: String!
+  directMessageChannel: DirectMessageChannel
+  dob: DateTime
+  email: String!
+  friends: [User!]!
+  id: Int!
+  joinDate: DateTime!
+  latestPost: Post
+  name: String!
+  password: String
+  registrationMethod: RegistrationMethod!
+  timezone: String!
+}
+
 type Location {
   coordinates: Point
   id: Int!
@@ -162,6 +178,7 @@ type Query {
   event(id: Int!): Event!
   events: [Event!]!
   friendCount: Int!
+  friends: [Friend!]!
   getChannelByEventId(channelName: String!, eventId: Int!): EventChannel!
   getDirectMessageChannel(toUserId: Int!): DirectMessageChannel
   hostEvents: [Event!]!

--- a/apps/mull-ui/src/app/pages/direct-message/direct-message.spec.tsx
+++ b/apps/mull-ui/src/app/pages/direct-message/direct-message.spec.tsx
@@ -1,3 +1,4 @@
+import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
@@ -8,9 +9,11 @@ describe('DirectMessage', () => {
   it('should render successfully', () => {
     const history = createMemoryHistory();
     const { baseElement } = render(
-      <Router history={history}>
-        <DirectMessagePage />
-      </Router>
+      <MockedProvider>
+        <Router history={history}>
+          <DirectMessagePage />
+        </Router>
+      </MockedProvider>
     );
     expect(baseElement).toBeTruthy();
   });

--- a/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
+++ b/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
@@ -1,35 +1,29 @@
+import { IUser } from '@mull/types';
 import React, { useState } from 'react';
+import { useFriendsQuery } from '../../../generated/graphql';
+import { avatarUrl } from '../../../utilities';
 import { ChatHeader, CustomTextInput } from '../../components';
 import ContactRow from '../../components/contact-row/contact-row';
 import './direct-message.scss';
 
-// TODO: Query that returns an array of user profiles related to user
-const userData = [
-  {
-    id: 1,
-    name: 'Bob Marley',
-    lastMessage: 'hi there',
-    picture:
-      'https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg',
-  },
-  {
-    id: 2,
-    name: 'Shawn Mendes',
-    lastMessage: 'meet up soon!',
-    picture:
-      'https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg',
-  },
-  {
-    id: 3,
-    name: 'Justin Bieber',
-    lastMessage: 'see you there',
-    picture:
-      'https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg',
-  },
-];
-
 const DirectMessagePage = () => {
   const [searchValue, setSearchValue] = useState('');
+  const { data, loading } = useFriendsQuery();
+
+  if (loading) return <div className="page-container">Loading...</div>;
+
+  const contactRows = data.friends
+    .filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
+    .map(({ latestPost, ...friend }, index) => (
+      <ContactRow
+        key={'contact-row-' + index}
+        userId={friend.id}
+        userName={friend.name}
+        lastMessage={latestPost ? latestPost.message : ''}
+        // TODO in TASK-63: an onClick event that will create a DM channel if it doesn't exist between the current user and their friend
+        userPicture={avatarUrl(friend as IUser)}
+      />
+    ));
 
   return (
     <div className="direct-messages-container">
@@ -44,21 +38,8 @@ const DirectMessagePage = () => {
           errorMessage={null}
           placeholder={'Search'}
         />
-
-        {userData.length > 0 ? (
-          userData.map((user, idx) => {
-            if (user.name.toLowerCase().includes(searchValue.toLowerCase()) || searchValue === '')
-              return (
-                <ContactRow
-                  key={idx}
-                  userId={user.id}
-                  userName={user.name}
-                  lastMessage={user.lastMessage}
-                  userPicture={user.picture}
-                />
-              );
-            return null;
-          })
+        {contactRows.length > 0 ? (
+          <div>{contactRows}</div>
         ) : (
           <p className="search-results">No results found</p>
         )}

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -80,6 +80,23 @@ export type EventChannel = {
   rights: Scalars['Int'];
 };
 
+export type Friend = {
+  __typename?: 'Friend';
+  avatar?: Maybe<Media>;
+  description: Scalars['String'];
+  directMessageChannel?: Maybe<DirectMessageChannel>;
+  dob?: Maybe<Scalars['DateTime']>;
+  email: Scalars['String'];
+  friends: Array<User>;
+  id: Scalars['Int'];
+  joinDate: Scalars['DateTime'];
+  latestPost?: Maybe<Post>;
+  name: Scalars['String'];
+  password?: Maybe<Scalars['String']>;
+  registrationMethod: RegistrationMethod;
+  timezone: Scalars['String'];
+};
+
 export type Location = {
   __typename?: 'Location';
   coordinates?: Maybe<Point>;
@@ -266,6 +283,7 @@ export type Query = {
   event: Event;
   events: Array<Event>;
   friendCount: Scalars['Int'];
+  friends: Array<Friend>;
   getChannelByEventId: EventChannel;
   getDirectMessageChannel?: Maybe<DirectMessageChannel>;
   hostEvents: Array<Event>;
@@ -633,6 +651,27 @@ export type ChannelByEventIdQuery = (
       ) }
     )> }
   ) }
+);
+
+export type FriendsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FriendsQuery = (
+  { __typename?: 'Query' }
+  & { friends: Array<(
+    { __typename?: 'Friend' }
+    & Pick<Friend, 'id' | 'name'>
+    & { avatar?: Maybe<(
+      { __typename?: 'Media' }
+      & Pick<Media, 'id' | 'mediaType'>
+    )>, directMessageChannel?: Maybe<(
+      { __typename?: 'DirectMessageChannel' }
+      & Pick<DirectMessageChannel, 'id'>
+    )>, latestPost?: Maybe<(
+      { __typename?: 'Post' }
+      & Pick<Post, 'id' | 'message'>
+    )> }
+  )> }
 );
 
 export type PostAddedSubscriptionVariables = Exact<{
@@ -1242,6 +1281,50 @@ export function useChannelByEventIdLazyQuery(baseOptions?: Apollo.LazyQueryHookO
 export type ChannelByEventIdQueryHookResult = ReturnType<typeof useChannelByEventIdQuery>;
 export type ChannelByEventIdLazyQueryHookResult = ReturnType<typeof useChannelByEventIdLazyQuery>;
 export type ChannelByEventIdQueryResult = Apollo.QueryResult<ChannelByEventIdQuery, ChannelByEventIdQueryVariables>;
+export const FriendsDocument = gql`
+    query Friends {
+  friends {
+    id
+    name
+    avatar {
+      id
+      mediaType
+    }
+    directMessageChannel {
+      id
+    }
+    latestPost {
+      id
+      message
+    }
+  }
+}
+    `;
+
+/**
+ * __useFriendsQuery__
+ *
+ * To run a query within a React component, call `useFriendsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFriendsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFriendsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useFriendsQuery(baseOptions?: Apollo.QueryHookOptions<FriendsQuery, FriendsQueryVariables>) {
+        return Apollo.useQuery<FriendsQuery, FriendsQueryVariables>(FriendsDocument, baseOptions);
+      }
+export function useFriendsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FriendsQuery, FriendsQueryVariables>) {
+          return Apollo.useLazyQuery<FriendsQuery, FriendsQueryVariables>(FriendsDocument, baseOptions);
+        }
+export type FriendsQueryHookResult = ReturnType<typeof useFriendsQuery>;
+export type FriendsLazyQueryHookResult = ReturnType<typeof useFriendsLazyQuery>;
+export type FriendsQueryResult = Apollo.QueryResult<FriendsQuery, FriendsQueryVariables>;
 export const PostAddedDocument = gql`
     subscription PostAdded($channelId: Int!) {
   postAdded(channelId: $channelId) {

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -146,3 +146,21 @@ query ChannelByEventId($eventId: Int!, $channelName: String!) {
     }
   }
 }
+
+query Friends {
+  friends {
+    id
+    name
+    avatar {
+      id
+      mediaType
+    }
+    directMessageChannel {
+      id
+    }
+    latestPost {
+      id
+      message
+    }
+  }
+}


### PR DESCRIPTION
This PR closes #226 

**Notes**
* I took this opportunity to use the Friends query in the frontend to connect to the backend, which is an AC of #225

**How to test**
1. Create a user 
1. Go to http://localhost:4200/dms and it should say that no results were found
1. Next, it's time to add friends. Ensure this user each has a friend that:
    1. Does not have a DM channel between the current user
    1. Has a DM channel between the current user, but no posts within that channel
    1. Has a DM channel between the current user, AND has posts within that channel
    1. Please note that creating DM channels, adding friends, and adding posts to that DM channel is still done via your favorite GraphQL playground
1. Going to http://localhost:4200/dms should show the accurate DMs list