### PR TITLE
TASK-66: Click Waste Recognition Page

### DIFF
--- a/apps/mull-ui/src/app/pages/waste-recognition-page/identified-waste-modal.tsx
+++ b/apps/mull-ui/src/app/pages/waste-recognition-page/identified-waste-modal.tsx
@@ -2,7 +2,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Dialog } from '@material-ui/core';
 import React, { useState } from 'react';
-import { svgMap } from '../../../utilities';
+import { WasteTypeSvgMap } from '../../../constants';
 import './identified-waste-page.scss';
 
 export interface IdentifiedWasteModalProps {
@@ -18,7 +18,7 @@ export const IdentifiedWasteModal = ({
   wastePicture,
   wasteInfo,
 }: IdentifiedWasteModalProps) => {
-  wasteIcon = '../../.' + svgMap[1];
+  wasteIcon = WasteTypeSvgMap[1];
   wasteTitle = 'This is recyclable!';
   wastePicture = 'http://pm1.narvii.com/5951/2922186bdf76edeb36250994eb99f1c32f31aea9_00.jpg';
   wasteInfo = 'Needs to be cleaned before recycling. Otherwise it goes to trashbin.';

--- a/apps/mull-ui/src/app/pages/waste-recognition-page/waste-recognition-page.tsx
+++ b/apps/mull-ui/src/app/pages/waste-recognition-page/waste-recognition-page.tsx
@@ -19,7 +19,6 @@ export function WasteRecognitionPage(props: WasteRecognitionPageProps) {
   const resultRef = useRef<DetectionResult[]>([]);
   const { notifyToast } = useToast();
 
-  const [videoLoading, setVideoLoading] = useState<boolean>(true);
   const [modelLoading, setModelLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -65,7 +64,7 @@ export function WasteRecognitionPage(props: WasteRecognitionPageProps) {
 
   const setupCamera = async () => {
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-      const cameraPromise = navigator.mediaDevices
+      return navigator.mediaDevices
         .getUserMedia({
           video: { facingMode: 'environment' },
           audio: false,
@@ -85,12 +84,10 @@ export function WasteRecognitionPage(props: WasteRecognitionPageProps) {
 
           return new Promise<MediaStream>((resolve, reject) => {
             videoRef.current.onloadedmetadata = () => {
-              setVideoLoading(false);
               resolve(stream);
             };
           });
         });
-      return cameraPromise;
     } else {
       throw new Error(
         'Either no camera exists on your device, or your browser denied access to it'

--- a/apps/mull-ui/src/app/pages/waste-recognition-page/waste-recognition-page.tsx
+++ b/apps/mull-ui/src/app/pages/waste-recognition-page/waste-recognition-page.tsx
@@ -140,7 +140,7 @@ export function WasteRecognitionPage(props: WasteRecognitionPageProps) {
     };
     const imageCoords = canvasToImageCoords(canvasCoords, canvasSize, imageSize);
 
-    let clickedObjects = resultRef.current.filter((result) =>
+    const clickedObjects = resultRef.current.filter((result) =>
       coordsInBox(imageCoords, result.bndBox)
     );
 

--- a/apps/mull-ui/src/constants.ts
+++ b/apps/mull-ui/src/constants.ts
@@ -1,4 +1,5 @@
 import { DetectionResult, EventRestriction, ISerializedEvent } from '@mull/types';
+import { WasteType } from './app/services/maps';
 
 /**
  * enum of the current routes for the application
@@ -170,3 +171,10 @@ export const monthNames = [
   'Nov',
   'Dec',
 ];
+
+export const WasteTypeSvgMap = {
+  [WasteType.COMPOST]: 'assets/icons/trash-recognition-icons/CompostIcon.svg',
+  [WasteType.EWASTE]: 'assets/icons/trash-recognition-icons/GeneralIcon.svg',
+  [WasteType.TRASH]: 'assets/icons/trash-recognition-icons/TrashIcon.svg',
+  [WasteType.RECYCLABLE]: 'assets/icons/trash-recognition-icons/RecycleIcon.svg',
+};

--- a/apps/mull-ui/src/utilities.spec.ts
+++ b/apps/mull-ui/src/utilities.spec.ts
@@ -1,5 +1,6 @@
+import { BoundingBox, Coordinates, Size } from '@mull/types';
 import { dummyDetectionResults } from './constants';
-import { drawDetectionIcons } from './utilities';
+import { canvasToImageCoords, coordsInBox, drawDetectionIcons } from './utilities';
 
 describe('Utilities', () => {
   describe('drawDetectionIcons', () => {
@@ -44,10 +45,59 @@ describe('Utilities', () => {
 
       setTimeout(() => {
         expect(canvas.getContext.mock.calls.length).toBe(1);
-        expect(canvas.getContext().strokeRect.mock.calls[0]).toEqual([20, 20, 100, 50]);
-        expect(canvas.getContext().strokeText.mock.calls[0]).toEqual(['recyclable: 80.0%', 20, 40]);
+        expect(canvas.getContext().strokeRect.mock.calls[0]).toEqual([20, 40, 100, 50]);
+        expect(canvas.getContext().strokeText.mock.calls[0]).toEqual(['recyclable: 80.0%', 20, 35]);
         done();
       }, 200);
+    });
+  });
+
+  describe('canvasToImageCoords', () => {
+    it('should convert canvas coordinates to image space correctly', () => {
+      const canvasCoords: Coordinates = {
+        x: 250,
+        y: 250,
+      };
+
+      const canvas: Size = {
+        width: 500,
+        height: 500,
+      };
+
+      // Image is wider than canvas
+      let image: Size = {
+        width: 300,
+        height: 200,
+      };
+      expect(canvasToImageCoords(canvasCoords, canvas, image)).toStrictEqual({ x: 150, y: 100 });
+
+      // Image is thinner than canvas
+      image = {
+        width: 200,
+        height: 400,
+      };
+      expect(canvasToImageCoords(canvasCoords, canvas, image)).toStrictEqual({ x: 100, y: 200 });
+    });
+  });
+  describe('coordsInBox', () => {
+    it('should convert canvas coordinates to image space correctly', () => {
+      const box: BoundingBox = {
+        x: 50,
+        y: 50,
+        width: 200,
+        height: 200,
+      };
+      let coords: Coordinates = {
+        x: 150,
+        y: 150,
+      };
+      expect(coordsInBox(coords, box)).toStrictEqual(true);
+
+      coords = {
+        x: 20,
+        y: 40,
+      };
+      expect(coordsInBox(coords, box)).toStrictEqual(false);
     });
   });
 });

--- a/apps/mull-ui/src/utilities.ts
+++ b/apps/mull-ui/src/utilities.ts
@@ -71,14 +71,14 @@ export const drawDetectionIcons = (
     if (debug) {
       ctx.strokeStyle = '#00ff00';
       ctx.font = '20px Courier';
-      ctx.strokeRect(box.x, box.y - 20, box.width, box.height);
-      ctx.strokeText(`${result.class}: ${(result.confidence * 100).toFixed(1)}%`, box.x, box.y);
+      ctx.strokeRect(box.x, box.y, box.width, box.height);
+      ctx.strokeText(`${result.class}: ${(result.confidence * 100).toFixed(1)}%`, box.x, box.y - 5);
     }
     var icon = new Image();
     icon.onload = () => {
       ctx.drawImage(icon, dx, dy, svgSize, svgSize);
     };
-    icon.src = svgMap[category];
+    icon.src = WasteTypeSvgMap[category];
   });
 };
 

--- a/apps/mull-ui/src/utilities.ts
+++ b/apps/mull-ui/src/utilities.ts
@@ -106,16 +106,16 @@ export const canvasToImageCoords = (
     imageCoords.y = (canvasCoords.y / canvas.height) * image.height;
 
     // Since the sides of the canvas have white padding, we need to find the offset to counterbalance this
-    let trueWidth = (canvas.height / image.height) * image.width;
-    let xOffset = (canvas.width - trueWidth) / 2;
+    const trueWidth = (canvas.height / image.height) * image.width;
+    const xOffset = (canvas.width - trueWidth) / 2;
     imageCoords.x = ((canvasCoords.x - xOffset) / trueWidth) * image.width;
   } else {
     // Canvas wider than image. There is padding on the top/bottom of the image
     imageCoords.x = (canvasCoords.x / canvas.width) * image.width;
 
     // Since the top/bottom of the canvas have white padding, we need to find the offset to counterbalance this
-    let trueHeight = (canvas.width / image.width) * image.height;
-    let offsetY = (canvas.height - trueHeight) / 2;
+    const trueHeight = (canvas.width / image.width) * image.height;
+    const offsetY = (canvas.height - trueHeight) / 2;
     imageCoords.y = ((canvasCoords.y - offsetY) / trueHeight) * image.height;
   }
 

--- a/apps/mull-ui/src/utilities.ts
+++ b/apps/mull-ui/src/utilities.ts
@@ -1,6 +1,7 @@
 import { BoundingBox, Coordinates, DetectionResult, ISerializedEvent, Size } from '@mull/types';
 import emojiRegexRGI from 'emoji-regex/es2015/RGI_Emoji.js';
-import { categoryMap, WasteType } from './app/services/maps';
+import { categoryMap } from './app/services/maps';
+import { WasteTypeSvgMap } from './constants';
 import { environment } from './environments/environment';
 import { User } from './generated/graphql';
 
@@ -42,12 +43,6 @@ export const mediaUrl = (event: Partial<ISerializedEvent>) =>
   `${environment.backendUrl}/api/media/${event.image.id}`;
 
 const svgSize = 45;
-export const svgMap = {
-  [WasteType.COMPOST]: './assets/icons/trash-recognition-icons/CompostIcon.svg',
-  [WasteType.EWASTE]: './assets/icons/trash-recognition-icons/GeneralIcon.svg',
-  [WasteType.TRASH]: './assets/icons/trash-recognition-icons/TrashIcon.svg',
-  [WasteType.RECYCLABLE]: './assets/icons/trash-recognition-icons/RecycleIcon.svg',
-};
 
 export const avatarUrl = (user: Partial<User>) =>
   user.avatar

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from './forms';
 export * from './host.env';
+export * from './ml';
 export * from './types';

--- a/libs/types/src/ml.ts
+++ b/libs/types/src/ml.ts
@@ -1,0 +1,17 @@
+export interface Coordinates {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface BoundingBox extends Coordinates, Size {}
+
+export interface DetectionResult {
+  class: string;
+  bndBox: BoundingBox;
+  confidence: number;
+}

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -96,19 +96,6 @@ export class IGooglePlace {
   placeId: string;
 }
 
-export interface DetectionResult {
-  class: string;
-  bndBox: BoundingBox;
-  confidence: number;
-}
-
-export interface BoundingBox {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
 export interface IWebSocketParams {
   authToken: string;
 }


### PR DESCRIPTION
closes #230 

This PR aims to implement the code and math needed to know when a user presses on an object when they are on the waste recognition page. this will serve to make #34 easier.

How to test:
1. start frontend and backend application
2. navigate to the camera page
3. Open the console to see console output
4. Try to get an object that is easily/consistently detected by the model in the frame (no flickering)
4. Click on the object
5. See the console output and check if it makes sense

Bonus: You can turn on debug mode by setting `debug` to true in the call to `drawDetectionIcons` in `waste-recognition-page.tsx`. You will then be able to see the rectangles which make up the detections and check if clicking inside/outside the rectangles works as intended.
```typescript
drawDetectionIcons(canvas, resultRef.current); // From this
drawDetectionIcons(canvas, resultRef.current, true); // To this
```

Example: 
![image](https://user-images.githubusercontent.com/23544999/110677591-545d8700-81a3-11eb-8741-26379020fec8.png)

Note: If the detection type/class (detecting your hand as a box for example) seems wrong, it's probably due to the model detecting something incorrectly, and not due to the code in this PR. That issue will be addressed separately by updating the model with better training.

See commit messages for details on changes.

