### PR TITLE
SONARCLOUD 8: Resolve Code Smells

### DIFF
--- a/apps/mull-ui/src/app/pages/create-event/create-event.scss
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.scss
@@ -54,6 +54,7 @@
     align-items: flex-start;
     font-weight: 600;
     line-height: 1.5;
+    align-self: flex-start;
   }
 
   .description-input-icon {
@@ -80,10 +81,6 @@
   ::-webkit-scrollbar-track-piece:start {
     background: #f1f1f1;
     margin-top: 0.625rem;
-  }
-
-  .description-label {
-    align-self: flex-start;
   }
 
   .description-msg {

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -56,13 +56,11 @@ export const EventChat = ({ eventId, channelName, restrictChatInput }: EventChat
         if (!subscriptionData.data) return prev;
         const newPostItem = subscriptionData.data.postAdded;
         //Add the new message received from the subscriber
-        const newList = Object.assign({}, prev, {
+        return Object.assign({}, prev, {
           getChannelByEventId: {
             posts: [...prev.getChannelByEventId.posts, newPostItem],
           },
         });
-
-        return newList;
       },
     });
 

--- a/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
@@ -4,7 +4,6 @@ import { useOwnedEventsQuery, useParticipantEventsQuery } from '../../../../gene
 import { mediaUrl } from '../../../../utilities';
 import { CustomTextInput } from '../../../components';
 import { EventBullet } from '../../../components/event-bullet/event-bullet';
-import './event-message-list.scss';
 
 export const EventMessageList = () => {
   const { data: participatingData, loading: participatingLoading } = useParticipantEventsQuery();


### PR DESCRIPTION
This PR addresses 3 code smells brought up by SonarCloud:

- Remove duplicate class name in Create Events
- Immediately return newList instead of using a temp variable
- Delete empty SCSS file for Event Messages List

You can access the SonarCloud dashboard [here](https://sonarcloud.io/dashboard?id=RGPosadas_Mull).