### PR TITLE
TASK-75: Prod WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We try our best to adhere to the set of rules and guidelines that we've come up 
 
 ### Environment
 
-We use **NodeJS 14**, **npm 7**, and Nx to manage our workspace and dependencies. The Nx CLI offers powerful tools for development, and we recommend you install it when contributing to the project.
+We use **NodeJS 14**, **npm 6**, and Nx to manage our workspace and dependencies. The Nx CLI offers powerful tools for development, and we recommend you install it when contributing to the project.
 
 1. Install NodeJS 14 for your operating system.
 1. Install npm 6 (if it wasn't included in your NodeJS installation or you have a different version)

--- a/apps/mull-api/Dockerfile
+++ b/apps/mull-api/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:12 as build
+FROM node:14 as build
 
 WORKDIR /usr/src/app
 
 COPY ./ ./
 
-RUN npm i
+RUN npm i --unsafe-perm
 RUN npm run build-api
 
 # create unprivileged user

--- a/apps/mull-ui/Dockerfile
+++ b/apps/mull-ui/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:12 as build
+FROM node:14 as build
 
 WORKDIR /mull-ui
 
 COPY ./ ./
 
-RUN npm i
+RUN npm i --unsafe-perm
 RUN npm run build-ui
 
 FROM nginx:stable-alpine

--- a/apps/mull-ui/src/environments/environment.prod.ts
+++ b/apps/mull-ui/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   backendUrl: '',
-  backendWsUrl: '',
+  backendWsUrl: 'wss://www.mullapp.com',
 };

--- a/apps/mull-ui/src/manifest.json
+++ b/apps/mull-ui/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Müll",
   "short_name": "Müll",
-  "start_url": "https://mullapp.com",
+  "start_url": "https://www.mullapp.com",
   "display": "standalone",
   "theme_color": "white",
   "background_color": "white",


### PR DESCRIPTION
This PR closes #269 

**Notes**
- I added the `--unsafe-perm` flag to `npm i` in order for the preinstall script to work ([ref ticket](https://stackoverflow.com/questions/18136746/npm-install-failed-with-cannot-run-in-wd)) when building the images. Without this flag, we run into this [issue](https://github.com/jaydenseric/graphql-upload/issues/170#issuecomment-707934264) with graphql-upload once again.
- Took this opportunity to fix the typo in manifest.json. Now when you run the PWA report on incognito mode, it should pass on both mobile and desktop.

**How to test**
Currently, my changes are running on prod.
- Go to www.mullapp.com
- Try to chat!