### PR TITLE
BUG-17: Event images are deleted when running backend tests

### DIFF
--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -2,6 +2,7 @@ import { InternalServerErrorException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { unlinkSync } from 'fs';
+import { join } from 'path';
 import { Media } from '../entities';
 import {
   mockAllMedias,
@@ -43,13 +44,8 @@ describe('MediaService', () => {
   });
 
   afterAll(() => {
-    unlinkSync(`${service.getRoute()}/0.jpeg`);
-    unlinkSync(`${service.getRoute()}/1.jpeg`);
-    unlinkSync(`${service.getRoute()}/2.png`);
-    unlinkSync(`${service.getRoute()}/2.jpeg`);
-    unlinkSync(`${service.getRoute()}/undefined.jpeg`);
-    unlinkSync(`${service.getRoute()}/zoro.jpeg`);
-    unlinkSync(`${service.getRoute()}/luffy.png`);
+    unlinkSync(join(process.cwd(), `${service.getRoute()}/0.jpeg`));
+    unlinkSync(join(process.cwd(), `${service.getRoute()}/2.png`));
   });
 
   it('should be defined', () => {

--- a/apps/mull-api/src/app/media/media.service.spec.ts
+++ b/apps/mull-api/src/app/media/media.service.spec.ts
@@ -39,16 +39,17 @@ describe('MediaService', () => {
     }).compile();
 
     service = module.get<MediaService>(MediaService);
+    service.setTesting(true);
   });
 
   afterAll(() => {
-    unlinkSync(`apps/mull-api/uploads/0.jpeg`);
-    unlinkSync(`apps/mull-api/uploads/1.jpeg`);
-    unlinkSync(`apps/mull-api/uploads/2.png`);
-    unlinkSync(`apps/mull-api/uploads/2.jpeg`);
-    unlinkSync(`apps/mull-api/uploads/undefined.jpeg`);
-    unlinkSync(`apps/mull-api/uploads/zoro.jpeg`);
-    unlinkSync(`apps/mull-api/uploads/luffy.png`);
+    unlinkSync(`${service.getRoute()}/0.jpeg`);
+    unlinkSync(`${service.getRoute()}/1.jpeg`);
+    unlinkSync(`${service.getRoute()}/2.png`);
+    unlinkSync(`${service.getRoute()}/2.jpeg`);
+    unlinkSync(`${service.getRoute()}/undefined.jpeg`);
+    unlinkSync(`${service.getRoute()}/zoro.jpeg`);
+    unlinkSync(`${service.getRoute()}/luffy.png`);
   });
 
   it('should be defined', () => {

--- a/apps/mull-api/src/app/media/media.service.ts
+++ b/apps/mull-api/src/app/media/media.service.ts
@@ -9,6 +9,10 @@ import { MediaInput } from './inputs/media.input';
 
 @Injectable()
 export class MediaService {
+  private route = '/apps/mull-api/uploads';
+  private testRoute = '/apps/mull-api/uploads/testing';
+  private testing = false;
+
   constructor(
     @InjectRepository(Media)
     private mediaRepository: Repository<Media>
@@ -43,7 +47,7 @@ export class MediaService {
   saveFile({ createReadStream, filename }: FileUpload): Promise<boolean> {
     return new Promise((resolve, reject) => {
       createReadStream().pipe(
-        createWriteStream(join(process.cwd(), `/apps/mull-api/uploads/${filename}`))
+        createWriteStream(join(process.cwd(), `${this.getRoute()}/${filename}`))
           .on('finish', () => resolve(true))
           .on('error', () => {
             reject(false);
@@ -66,8 +70,8 @@ export class MediaService {
 
   updateFilename(prevFilename: string, nextFilename: number, fileType: string): boolean {
     renameSync(
-      join(process.cwd(), `/apps/mull-api/uploads/${prevFilename}`),
-      join(process.cwd(), `/apps/mull-api/uploads/${nextFilename}.${fileType}`)
+      join(process.cwd(), `${this.getRoute()}/${prevFilename}`),
+      join(process.cwd(), `${this.getRoute()}/${nextFilename}.${fileType}`)
     );
     return true;
   }
@@ -77,7 +81,15 @@ export class MediaService {
   }
 
   deleteStoredFile(media: MediaInput): boolean {
-    unlinkSync(join(process.cwd(), `/apps/mull-api/uploads/${media.id}.${media.mediaType}`));
+    unlinkSync(join(process.cwd(), `${this.getRoute()}/${media.id}.${media.mediaType}`));
     return true;
+  }
+
+  public setTesting(testing: boolean) {
+    this.testing = testing;
+  }
+
+  public getRoute(): string {
+    return this.testing ? this.testRoute : this.route;
   }
 }


### PR DESCRIPTION
closes #241 

Files under uploads/ are prod files and shouldn't be touched by tests. Tests now manipulate files under a different directory.

Now, after you run backend tests, files under `uploads/` shouldn't be touched, and any files created under `uploads/testing` should be all deleted.
