### PR TITLE
BUG-23: "Show more" button submits create event form

### DIFF
--- a/apps/mull-ui/src/app/components/expandable-text/expandable-text.tsx
+++ b/apps/mull-ui/src/app/components/expandable-text/expandable-text.tsx
@@ -24,6 +24,7 @@ export const ExpandableText = ({ children, cutoff = 150, className = '' }: Expan
         <>
           {expand ? ' ' : '... '}
           <button
+            type="button"
             data-testid="expandable-text-button"
             className="expandable-span-button"
             onClick={() => setExpand(!expand)}

--- a/apps/mull-ui/src/app/pages/event-page/event-page-info/__snapshots__/event-page-info.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/event-page/event-page-info/__snapshots__/event-page-info.spec.tsx.snap
@@ -111,6 +111,7 @@ exports[`EventPageInfo should match snapshot 1`] = `
         className="expandable-span-button"
         data-testid="expandable-text-button"
         onClick={[Function]}
+        type="button"
       >
         more
       </button>


### PR DESCRIPTION
closes #309

How to test:
- Fill create event form with long description
- On review page, click on `more`

The form should not be submitted, and the event should not be created.

![image](https://user-images.githubusercontent.com/23544999/113196352-688c2580-9231-11eb-9415-3daea351403e.png)
