### PR TITLE
BUG-25: New Event Assigned Random Image

### DIFF
--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -37,7 +37,7 @@ export const EventCard = ({
   const isEventExpired = currentDate.getTime() > new Date(event.endDate).getTime();
   return (
     <div className="event-card-container button" onClick={onClick} style={style}>
-      <img className="event-card-image" src={getMediaUrl(event.id)} alt="Event" />
+      <img className="event-card-image" src={getMediaUrl(event.image.id)} alt="Event" />
       <div className="event-card-datetime" data-testid="event-card-datetime">
         <div className="date-style">{`${day} ${month.toUpperCase()}`}</div>
         <div>{time.replace(/\s/g, '')}</div>

--- a/apps/mull-ui/src/app/pages/event-page/event-page-header/event-page-header.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page-header/event-page-header.tsx
@@ -52,7 +52,7 @@ export const EventPageHeader = ({
       <img
         className="event-image"
         data-testid="event-page-image"
-        src={eventImageURL ? eventImageURL : getMediaUrl(event.id)}
+        src={eventImageURL ? eventImageURL : getMediaUrl(event.image.id)}
         alt="Event Page"
         // Check header size after image has loaded
         onLoad={handleHeaderChange}

--- a/apps/mull-ui/src/app/pages/event-page/event-page-info/event-page-info.tsx
+++ b/apps/mull-ui/src/app/pages/event-page/event-page-info/event-page-info.tsx
@@ -110,7 +110,7 @@ export const EventPageInfo = ({
           <img
             className="cancel-modal-event-image"
             data-testid="event-page-image"
-            src={eventImageURL ? eventImageURL : getMediaUrl(event.id)}
+            src={eventImageURL ? eventImageURL : getMediaUrl(event.image.id)}
             alt="Event Page"
           />
 

--- a/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
@@ -21,7 +21,7 @@ export const EventMessageList = () => {
     .map((event, index) => (
       <EventBullet
         eventTitle={event.title}
-        eventPicture={getMediaUrl(event.id)}
+        eventPicture={getMediaUrl(event.image.id)}
         eventDate={new Date(event.startDate)}
         key={'event-bullet-' + index}
       />


### PR DESCRIPTION
Closes #325

Fixes a bug I introduced after merging media in posts where the image of the event image showing is the id of the event rather than the id of the image.  