### PR TITLE
BUG-19: Profile page profile picture is not always a circle

### DIFF
--- a/apps/mull-ui/src/app/components/profile-header/profile-header.scss
+++ b/apps/mull-ui/src/app/components/profile-header/profile-header.scss
@@ -24,7 +24,7 @@
 
 .profile-side-container,
 .for-current-user {
-  width: 100%;
+  flex: 1;
   text-align: center;
 }
 

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -68,6 +68,7 @@ button,
   box-sizing: border-box;
   width: 5rem;
   height: 5rem;
+  min-height: 5rem;
   object-fit: cover;
   border-radius: 50%;
   border: 1px solid black;


### PR DESCRIPTION
This PR closes #254 

To test this PR:

1. Go to Profile Page
2. Edit image and choose a long vertical image.
3. Update image
4. Image is a circle and not oval shaped anymore.