### PR TITLE
TASK-78: Add Friends Frontend

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -24,6 +24,7 @@ import AnnouncementsPage from './pages/messages/announcements/announcements';
 import ChatPagesHeader from './pages/messages/chat-pages-header';
 import EventMessageList from './pages/messages/event-messages/event-message-list';
 import GroupChatPage from './pages/messages/group-chat/group-chat';
+import AddFriendsPage from './pages/profile/add-friends/add-friends';
 import EditProfilePage from './pages/profile/edit-profile/edit-profile';
 import OtherUserProfilePage from './pages/profile/other-user-profile/other-user-profile';
 import UserProfilePage from './pages/profile/user-profile/user-profile';
@@ -132,7 +133,7 @@ export const App = () => {
           <PrivateRoute path={ROUTES.SETTINGS} component={SettingsPage} />
           {/*TODO in TASK-83: route user profiles to /user/${user.id} */}
           <PrivateRoute path={ROUTES.OTHER_USER_PROFILE} component={OtherUserProfilePage} />
-
+          <PrivateRoute path={ROUTES.PROFILE.ADDFRIENDS} component={AddFriendsPage} />
           <PrivateRoute component={NotFoundPage} />
         </Switch>
 

--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -128,12 +128,12 @@ export const App = () => {
           {/* TODO: Messages main page: Add swipeable routes for DM + Event Message page */}
           <PrivateRoute path={ROUTES.DIRECT_MESSAGES} component={DirectMessagePage} />
           <PrivateRoute path={ROUTES.EVENT_MESSAGE_LIST} component={EventMessageList} />
+          <PrivateRoute path={ROUTES.PROFILE.ADDFRIENDS} component={AddFriendsPage} />
           <PrivateRoute path={ROUTES.PROFILE.EDIT} component={EditProfilePage} />
           <PrivateRoute exact path={ROUTES.PROFILE.DISPLAY} component={UserProfilePage} />
           <PrivateRoute path={ROUTES.SETTINGS} component={SettingsPage} />
           {/*TODO in TASK-83: route user profiles to /user/${user.id} */}
           <PrivateRoute path={ROUTES.OTHER_USER_PROFILE} component={OtherUserProfilePage} />
-          <PrivateRoute path={ROUTES.PROFILE.ADDFRIENDS} component={AddFriendsPage} />
           <PrivateRoute component={NotFoundPage} />
         </Switch>
 

--- a/apps/mull-ui/src/app/components/contact-row/contact-row.scss
+++ b/apps/mull-ui/src/app/components/contact-row/contact-row.scss
@@ -16,6 +16,7 @@
     display: flex;
     padding: 0.3rem;
     flex-direction: column;
+    align-self: center;
     .username {
       margin-top: 0.5rem;
       font-weight: normal;

--- a/apps/mull-ui/src/app/components/contact-row/contact-row.scss
+++ b/apps/mull-ui/src/app/components/contact-row/contact-row.scss
@@ -11,6 +11,7 @@
   .user-profile-picture {
     width: 3.5rem !important;
     height: 3.5rem !important;
+    min-height: 3.5rem !important;
   }
   .user-details {
     display: flex;

--- a/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
+++ b/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
@@ -10,12 +10,19 @@ import './contact-row.scss';
 /* eslint-disable-next-line */
 export interface ContactRowProps {
   userId?: number;
-  userName?: string;
+  userPicture?: string;
   lastMessage?: string;
+  userName?: string;
   icon: IconProp;
 }
 
-export const ContactRow = ({ userId, userName, lastMessage, icon }: ContactRowProps) => {
+export const ContactRow = ({
+  userId,
+  userPicture,
+  userName,
+  lastMessage,
+  icon,
+}: ContactRowProps) => {
   const user: Partial<User> = {
     name: `${userName}`,
   };

--- a/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
+++ b/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
@@ -1,39 +1,55 @@
-import { faEllipsisH } from '@fortawesome/free-solid-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React from 'react';
+import { User } from 'apps/mull-ui/src/generated/graphql';
+import { avatarUrl } from 'apps/mull-ui/src/utilities';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import FriendModal from '../modal/friend-modal/friend-modal';
 import './contact-row.scss';
 
 /* eslint-disable-next-line */
 export interface ContactRowProps {
   userId?: number;
-  userPicture?: string;
   userName?: string;
   lastMessage?: string;
-  onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
+  icon: IconProp;
 }
 
-export const ContactRow = ({
-  userId,
-  userPicture,
-  userName,
-  lastMessage,
-  onClick,
-}: ContactRowProps) => {
+export const ContactRow = ({ userId, userName, lastMessage, icon }: ContactRowProps) => {
+  const user: Partial<User> = {
+    name: `${userName}`,
+  };
+  const [open, setOpen] = useState(false);
+  const addedMe = false;
+
   return (
     <div className="contact-container">
       <Link to={`/profile/${userId}`}>
         <div className="user-information">
-          <img className="user-profile-picture" src={userPicture} alt="user" />
+          <img className="user-profile-picture" src={avatarUrl(user)} alt="user" />
           <div className="user-details">
             <span className="username">{userName}</span>
             <span className="last-message">{lastMessage}</span>
           </div>
         </div>
       </Link>
-      <button className="friend-settings-icon" onClick={onClick}>
-        <FontAwesomeIcon icon={faEllipsisH} />
+      <button className="friend-settings-icon" onClick={() => setOpen(true)}>
+        <FontAwesomeIcon icon={icon} />
       </button>
+      <FriendModal
+        open={open}
+        setOpen={setOpen}
+        user={user}
+        // TODO: Button should redirect to appropriate page
+        button1Text="View Profile"
+        button1OnClick={() => {
+          console.log('clicked 1');
+        }}
+        button2Text={addedMe ? 'Add Friend' : 'Cancel Request'}
+        button2OnClick={() => {
+          console.log('clicked 2');
+        }}
+      />
     </div>
   );
 };

--- a/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
+++ b/apps/mull-ui/src/app/components/contact-row/contact-row.tsx
@@ -1,9 +1,9 @@
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { User } from 'apps/mull-ui/src/generated/graphql';
-import { avatarUrl } from 'apps/mull-ui/src/utilities';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { User } from '../../../generated/graphql';
+import { avatarUrl } from '../../../utilities';
 import FriendModal from '../modal/friend-modal/friend-modal';
 import './contact-row.scss';
 
@@ -27,6 +27,8 @@ export const ContactRow = ({
     name: `${userName}`,
   };
   const [open, setOpen] = useState(false);
+
+  // TODO: Replace boolean by the appropriate button option according to query
   const addedMe = false;
 
   return (

--- a/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
+++ b/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
@@ -1,3 +1,4 @@
+import { faEllipsisH } from '@fortawesome/free-solid-svg-icons';
 import { IUser } from '@mull/types';
 import React, { useState } from 'react';
 import { useFriendsQuery } from '../../../generated/graphql';
@@ -20,6 +21,7 @@ const DirectMessagePage = () => {
         userId={friend.id}
         userName={friend.name}
         lastMessage={latestPost ? latestPost.message : ''}
+        icon={faEllipsisH}
         // TODO in TASK-63: an onClick event that will create a DM channel if it doesn't exist between the current user and their friend
         userPicture={avatarUrl(friend as IUser)}
       />

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.scss
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.scss
@@ -1,0 +1,7 @@
+.add-friends-title {
+  padding: 0.75rem 0 1.5rem 0;
+}
+
+.add-friend-individual {
+  margin-top: 2rem;
+}

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.spec.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.spec.tsx
@@ -1,0 +1,28 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { UserProvider } from '../../../context/user.context';
+import AddFriendsPage from './add-friends';
+
+describe('AddFriendsPage', () => {
+  const renderHelper = (history, mocks: MockedResponse[]) => {
+    return (
+      <UserProvider value={{ userId: 1, setUserId: jest.fn() }}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <AddFriendsPage />
+          </Router>
+        </MockedProvider>
+      </UserProvider>
+    );
+  };
+
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+
+    const { baseElement } = render(renderHelper(history, null));
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
@@ -18,6 +18,7 @@ export const AddFriendsPage = () => {
           title=""
           fieldName="searchValue"
           value=""
+          onChange={() => null}
           onClick={() => {
             setOpen(true);
           }}

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
@@ -1,31 +1,13 @@
 import { faEllipsisH, faSearch, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useFriendsQuery } from 'apps/mull-ui/src/generated/graphql';
 import React, { useState } from 'react';
 import { CustomTextInput, MullBackButton } from '../../../components';
 import ContactRow from '../../../components/contact-row/contact-row';
 import './add-friends.scss';
+import SearchUsersPage from './search-users';
 
 export const AddFriendsPage = () => {
-  const [searchValue, setSearchValue] = useState('');
-  const { data, loading } = useFriendsQuery();
-
-  if (loading) return <div className="page-container">Loading...</div>;
-
-  //   const contactRows = data.friends
-  //     .filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
-  //     .map(({ latestPost, ...friend }, index) => (
-  //       <ContactRow
-  //         key={'contact-row-' + index}
-  //         userId={friend.id}
-  //         userName={friend.name}
-  //         icon={fa}
-  //         // TODO in TASK-63: an onClick event that will create a DM channel if it doesn't exist between the current user and their friend
-  //         userPicture={avatarUrl(friend as IUser)}
-  //       />
-  //     ));
-
-  const searchMode = false;
+  const [open, setOpen] = useState(false);
 
   return (
     <div className="page-container">
@@ -35,36 +17,26 @@ export const AddFriendsPage = () => {
         <CustomTextInput
           title=""
           fieldName="searchValue"
-          value={searchValue}
-          onChange={(event) => setSearchValue(event.target.value)}
+          value=""
+          onClick={() => {
+            setOpen(true);
+          }}
           hasErrors={null}
           errorMessage={null}
           svgIcon={<FontAwesomeIcon className="input-icon" icon={faSearch} />}
           placeholder={'Find Friends'}
         />
-        {/* {contactRows.length > 0 ? (
-        <div>{contactRows}</div>
-      ) : (
-        <p className="search-results">No results found</p>
-      )} */}
-        {searchMode ? (
-          <div>
-            <ContactRow userId={213} userName={'John Doe'} icon={faUserPlus}></ContactRow>
-            <ContactRow userId={213} userName={'Jamie Doe'} icon={faUserPlus}></ContactRow>
-            <ContactRow userId={213} userName={'Jasmine Doe'} icon={faUserPlus}></ContactRow>
+        <SearchUsersPage open={open} setOpen={setOpen} />
+        <div>
+          <div className="add-friend-individual">
+            <h2>Added Me</h2>
+            <ContactRow userId={213} userName={'Jane Doe'} icon={faUserPlus}></ContactRow>
           </div>
-        ) : (
-          <div>
-            <div className="add-friend-individual">
-              <h2>Added Me</h2>
-              <ContactRow userId={213} userName={'Jane Doe'} icon={faUserPlus}></ContactRow>
-            </div>
-            <div className="add-friend-individual">
-              <h2>Pending Requests</h2>
-              <ContactRow userId={213} userName={'Donkey Kong'} icon={faEllipsisH}></ContactRow>
-            </div>
+          <div className="add-friend-individual">
+            <h2>Pending Requests</h2>
+            <ContactRow userId={213} userName={'Donkey Kong'} icon={faEllipsisH}></ContactRow>
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
@@ -1,0 +1,73 @@
+import { faEllipsisH, faSearch, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useFriendsQuery } from 'apps/mull-ui/src/generated/graphql';
+import React, { useState } from 'react';
+import { CustomTextInput, MullBackButton } from '../../../components';
+import ContactRow from '../../../components/contact-row/contact-row';
+import './add-friends.scss';
+
+export const AddFriendsPage = () => {
+  const [searchValue, setSearchValue] = useState('');
+  const { data, loading } = useFriendsQuery();
+
+  if (loading) return <div className="page-container">Loading...</div>;
+
+  //   const contactRows = data.friends
+  //     .filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
+  //     .map(({ latestPost, ...friend }, index) => (
+  //       <ContactRow
+  //         key={'contact-row-' + index}
+  //         userId={friend.id}
+  //         userName={friend.name}
+  //         icon={fa}
+  //         // TODO in TASK-63: an onClick event that will create a DM channel if it doesn't exist between the current user and their friend
+  //         userPicture={avatarUrl(friend as IUser)}
+  //       />
+  //     ));
+
+  const searchMode = false;
+
+  return (
+    <div className="page-container">
+      <MullBackButton>Profile</MullBackButton>
+      <div className="add-friends-container">
+        <h1 className="add-friends-title">Add Friends</h1>
+        <CustomTextInput
+          title=""
+          fieldName="searchValue"
+          value={searchValue}
+          onChange={(event) => setSearchValue(event.target.value)}
+          hasErrors={null}
+          errorMessage={null}
+          svgIcon={<FontAwesomeIcon className="input-icon" icon={faSearch} />}
+          placeholder={'Find Friends'}
+        />
+        {/* {contactRows.length > 0 ? (
+        <div>{contactRows}</div>
+      ) : (
+        <p className="search-results">No results found</p>
+      )} */}
+        {searchMode ? (
+          <div>
+            <ContactRow userId={213} userName={'John Doe'} icon={faUserPlus}></ContactRow>
+            <ContactRow userId={213} userName={'Jamie Doe'} icon={faUserPlus}></ContactRow>
+            <ContactRow userId={213} userName={'Jasmine Doe'} icon={faUserPlus}></ContactRow>
+          </div>
+        ) : (
+          <div>
+            <div className="add-friend-individual">
+              <h2>Added Me</h2>
+              <ContactRow userId={213} userName={'Jane Doe'} icon={faUserPlus}></ContactRow>
+            </div>
+            <div className="add-friend-individual">
+              <h2>Pending Requests</h2>
+              <ContactRow userId={213} userName={'Donkey Kong'} icon={faEllipsisH}></ContactRow>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AddFriendsPage;

--- a/apps/mull-ui/src/app/pages/profile/add-friends/search-users.spec.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/search-users.spec.tsx
@@ -1,0 +1,28 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { UserProvider } from '../../../context/user.context';
+import SearchUsersPage from './search-users';
+
+describe('SearchUsersPage', () => {
+  const renderHelper = (history, mocks: MockedResponse[]) => {
+    return (
+      <UserProvider value={{ userId: 1, setUserId: jest.fn() }}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <SearchUsersPage />
+          </Router>
+        </MockedProvider>
+      </UserProvider>
+    );
+  };
+
+  it('should render successfully', () => {
+    const history = createMemoryHistory();
+
+    const { baseElement } = render(renderHelper(history, null));
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/apps/mull-ui/src/app/pages/profile/add-friends/search-users.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/search-users.tsx
@@ -1,0 +1,69 @@
+import { faSearch, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Dialog } from '@material-ui/core';
+import { useFriendsQuery } from 'apps/mull-ui/src/generated/graphql';
+import React, { useState } from 'react';
+import { CustomTextInput, MullBackButton, TopNavBar } from '../../../components';
+import ContactRow from '../../../components/contact-row/contact-row';
+import './add-friends.scss';
+
+export interface SearchUsersPageProps {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const SearchUsersPage = ({ open, setOpen }: SearchUsersPageProps) => {
+  const [searchValue, setSearchValue] = useState('');
+
+  const { data, loading } = useFriendsQuery();
+
+  if (loading) return <div className="page-container">Loading...</div>;
+
+  const contactRows = data.friends
+    .filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
+    .map(({ latestPost, ...friend }, index) => (
+      <ContactRow
+        key={'contact-row-' + index}
+        userId={friend.id}
+        userName={friend.name}
+        lastMessage={latestPost ? latestPost.message : ''}
+        icon={faUserPlus}
+      />
+    ));
+
+  return (
+    <>
+      <Dialog fullScreen transitionDuration={5} open={open}>
+        <TopNavBar />
+        <div className="page-container">
+          <MullBackButton onClick={() => setOpen(false)}>Profile</MullBackButton>
+          <div className="add-friends-container">
+            <h1 className="add-friends-title">Add Friends</h1>
+            <CustomTextInput
+              title=""
+              fieldName="searchValue"
+              value={searchValue}
+              onChange={(event) => {
+                setSearchValue(event.target.value);
+              }}
+              hasErrors={null}
+              errorMessage={null}
+              svgIcon={<FontAwesomeIcon className="input-icon" icon={faSearch} />}
+              placeholder={'Find Friends'}
+            />
+            <div>
+              {contactRows.length > 0 ? (
+                <div>{contactRows}</div>
+              ) : (
+                <p className="search-results">No results found</p>
+              )}
+            </div>
+            <div></div>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+};
+
+export default SearchUsersPage;

--- a/apps/mull-ui/src/app/pages/profile/add-friends/search-users.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/search-users.tsx
@@ -1,8 +1,8 @@
 import { faSearch, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Dialog } from '@material-ui/core';
-import { useFriendsQuery } from 'apps/mull-ui/src/generated/graphql';
 import React, { useState } from 'react';
+import { useFriendsQuery } from '../../../../generated/graphql';
 import { CustomTextInput, MullBackButton, TopNavBar } from '../../../components';
 import ContactRow from '../../../components/contact-row/contact-row';
 import './add-friends.scss';
@@ -15,10 +15,12 @@ export interface SearchUsersPageProps {
 export const SearchUsersPage = ({ open, setOpen }: SearchUsersPageProps) => {
   const [searchValue, setSearchValue] = useState('');
 
+  // TODO: Replace the test query by the actual strangers query
   const { data, loading } = useFriendsQuery();
 
   if (loading) return <div className="page-container">Loading...</div>;
 
+  // TODO: Goes with the first TODO - filter by strangers
   const contactRows = data.friends
     .filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
     .map(({ latestPost, ...friend }, index) => (
@@ -32,37 +34,35 @@ export const SearchUsersPage = ({ open, setOpen }: SearchUsersPageProps) => {
     ));
 
   return (
-    <>
-      <Dialog fullScreen transitionDuration={5} open={open}>
-        <TopNavBar />
-        <div className="page-container">
-          <MullBackButton onClick={() => setOpen(false)}>Profile</MullBackButton>
-          <div className="add-friends-container">
-            <h1 className="add-friends-title">Add Friends</h1>
-            <CustomTextInput
-              title=""
-              fieldName="searchValue"
-              value={searchValue}
-              onChange={(event) => {
-                setSearchValue(event.target.value);
-              }}
-              hasErrors={null}
-              errorMessage={null}
-              svgIcon={<FontAwesomeIcon className="input-icon" icon={faSearch} />}
-              placeholder={'Find Friends'}
-            />
-            <div>
-              {contactRows.length > 0 ? (
-                <div>{contactRows}</div>
-              ) : (
-                <p className="search-results">No results found</p>
-              )}
-            </div>
-            <div></div>
+    <Dialog fullScreen transitionDuration={5} open={open}>
+      <TopNavBar />
+      <div className="page-container">
+        <MullBackButton onClick={() => setOpen(false)}>Profile</MullBackButton>
+        <div className="add-friends-container">
+          <h1 className="add-friends-title">Add Friends</h1>
+          <CustomTextInput
+            title=""
+            fieldName="searchValue"
+            value={searchValue}
+            onChange={(event) => {
+              setSearchValue(event.target.value);
+            }}
+            hasErrors={null}
+            errorMessage={null}
+            svgIcon={<FontAwesomeIcon className="input-icon" icon={faSearch} />}
+            placeholder={'Find Friends'}
+          />
+          <div>
+            {contactRows.length > 0 ? (
+              <div>{contactRows}</div>
+            ) : (
+              <p className="search-results">No results found</p>
+            )}
           </div>
+          <div></div>
         </div>
-      </Dialog>
-    </>
+      </div>
+    </Dialog>
   );
 };
 

--- a/apps/mull-ui/src/app/pages/profile/other-user-profile/__snapshots__/other-user-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/other-user-profile/__snapshots__/other-user-profile.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`OtherUserProfile should match snapshot 1`] = `
             onClick={[Function]}
             type="submit"
           >
-            
+            Add Friend
           </button>
         </div>
       </div>

--- a/apps/mull-ui/src/app/pages/profile/user-profile/__snapshots__/user-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/__snapshots__/user-profile.spec.tsx.snap
@@ -116,28 +116,33 @@ exports[`UserProfilePage should match snapshot 1`] = `
     <h3>
       Friends
     </h3>
-    <button
-      className="settings-button-container"
+    <a
+      href="/profile/add-friends"
+      onClick={[Function]}
     >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-user-plus fa-w-20 settings-icon"
-        data-icon="user-plus"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 640 512"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        className="settings-button-container"
       >
-        <path
-          d="M624 208h-64v-64c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v64h-64c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h64v64c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16v-64h64c8.8 0 16-7.2 16-16v-32c0-8.8-7.2-16-16-16zm-400 48c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-user-plus fa-w-20 settings-icon"
+          data-icon="user-plus"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-      Add Friends
-    </button>
+          viewBox="0 0 640 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M624 208h-64v-64c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v64h-64c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h64v64c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16v-64h64c8.8 0 16-7.2 16-16v-32c0-8.8-7.2-16-16-16zm-400 48c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        Add Friends
+      </button>
+    </a>
     <button
       className="settings-button-container"
     >

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.tsx
@@ -44,7 +44,9 @@ export const UserProfilePage = ({ history }: UserProfilePageProps) => {
       </div>
       <div className="settings-container with-friends">
         <h3>Friends</h3>
-        <SettingsButton icon={faUserPlus} text="Add Friends" />
+        <Link to={ROUTES.PROFILE.ADDFRIENDS}>
+          <SettingsButton icon={faUserPlus} text="Add Friends" />
+        </Link>
         <SettingsButton icon={faUserFriends} text="My Friends" />
         <p className={friendRequestExists ? 'friend-request-count' : 'no-friend-request'}>{4}</p>
       </div>

--- a/apps/mull-ui/src/constants.ts
+++ b/apps/mull-ui/src/constants.ts
@@ -14,7 +14,7 @@ export const ROUTES = {
   MESSAGES: '/messages',
   GROUPCHAT: { url: '/messages/group-chat', displayName: 'Group Chat' },
   ANNOUNCEMENTS: { url: '/messages/announcements', displayName: 'Announcements' },
-  PROFILE: { DISPLAY: '/profile', EDIT: '/profile/edit' },
+  PROFILE: { DISPLAY: '/profile', EDIT: '/profile/edit', ADDFRIENDS: '/profile/add-friends' },
   LOGIN: '/login',
   REGISTER: '/register',
   EVENT_BY_ID: '/events/:id',


### PR DESCRIPTION
This PR closes #276.

You can access the page by going to http://localhost:4200/profile/add-friends. 

In `search-users`, I am currently using the `useFriendsQuery()` as a placeholder to test the filtering, it will be replaced by its appropriate strangers query in the US.

In `contact-row`, the `addedMe` is a temporary boolean to test out the different button options depending on whether it is someone who added the me, or I added someone. 
