### PR TITLE
FIX: Adjust image styling

### DIFF
--- a/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.scss
@@ -1,4 +1,6 @@
 .chat-bubble-image {
   max-width: 11rem;
+  max-height: 12rem;
   display: block;
+  object-fit: contain;
 }

--- a/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.scss
+++ b/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.scss
@@ -34,6 +34,8 @@
   display: block;
   width: 100%;
   border-radius: 6.5px;
+  max-height: 12rem;
+  object-fit: contain;
 }
 
 .custom-file-upload-icon-container {

--- a/apps/mull-ui/src/app/components/event-bullet/event-bullet.scss
+++ b/apps/mull-ui/src/app/components/event-bullet/event-bullet.scss
@@ -7,8 +7,8 @@
 }
 
 .event-bullet-photo {
-  max-width: 5rem;
-  max-height: 3.3rem;
+  width: 5rem;
+  height: 3.3rem;
   border-radius: 15%;
   object-fit: contain;
 }

--- a/apps/mull-ui/src/app/components/event-bullet/event-bullet.scss
+++ b/apps/mull-ui/src/app/components/event-bullet/event-bullet.scss
@@ -3,13 +3,14 @@
   align-items: center;
   justify-content: left;
   position: relative;
-  padding: 1rem 0;
+  padding: 1rem 0.25rem;
 }
 
 .event-bullet-photo {
   max-width: 5rem;
-  max-height: 100%;
+  max-height: 3.3rem;
   border-radius: 15%;
+  object-fit: contain;
 }
 
 .event-bullet-date-box {

--- a/apps/mull-ui/src/app/pages/event-page/event-page-header/event-page-header.scss
+++ b/apps/mull-ui/src/app/pages/event-page/event-page-header/event-page-header.scss
@@ -17,6 +17,7 @@
   display: block;
   max-height: 9rem;
   margin: 0 auto;
+  max-width: 100%;
 }
 
 .event-datetime {
@@ -39,10 +40,6 @@
 }
 
 @media (min-width: $breakpoint-mobile) {
-  .event-image {
-    max-width: 100%;
-  }
-
   .event-page-title {
     margin-top: 1rem;
   }


### PR DESCRIPTION
closes #341
We weren't taking into account the use of wide and long images for the chat bubble, the file upload and the event bullet

Before:
![image](https://user-images.githubusercontent.com/23544999/113767615-e4ccb000-96ec-11eb-88f4-82c7948cf47c.png)
![image](https://user-images.githubusercontent.com/23544999/113767665-f57d2600-96ec-11eb-9474-b8af5d47c8fd.png)
![image](https://user-images.githubusercontent.com/23544999/113767819-20677a00-96ed-11eb-9a12-cbdd65ff0c30.png)



After: 
![image](https://user-images.githubusercontent.com/23544999/113769662-3b3aee00-96ef-11eb-9f28-4bfe2e5c8b62.png)
![image](https://user-images.githubusercontent.com/23544999/113769696-44c45600-96ef-11eb-9baf-3a6507c81f09.png)
![image](https://user-images.githubusercontent.com/23544999/113769711-49890a00-96ef-11eb-8395-867842155406.png)


