### PR TITLE
FIX: Fix wrong call to toast in login/register

### DIFF
--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -48,12 +48,13 @@ export const Login = ({ history }: LoginProps) => {
       try {
         var { data, errors } = await login({ variables: { loginInput } });
       } catch (err) {
-        updateToast(toast.TYPE.ERROR, err.message);
+        updateToast(err.message, toast.TYPE.ERROR);
         return;
       }
 
       if (errors) {
-        console.error(errors);
+        const messages = errors.map((err) => err.message).reduce((err1, err2) => `${err1} ${err2}`);
+        updateToast(`Error, user not created: ${messages}`, toast.TYPE.ERROR);
         return;
       }
 

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -51,12 +51,12 @@ const Register = ({ history }: RegisterProps) => {
       try {
         var { errors } = await createUser({ variables: { user } });
       } catch (err) {
-        updateToast(toast.TYPE.ERROR, err.message);
+        updateToast(err.message, toast.TYPE.ERROR);
         return;
       }
 
       if (errors) {
-        const messages = errors.map((err) => err.message).reduce((err1, err2) => err1 + err2);
+        const messages = errors.map((err) => err.message).reduce((err1, err2) => `${err1} ${err2}`);
         updateToast(`Error, user not created: ${messages}`, toast.TYPE.ERROR);
         return;
       }


### PR DESCRIPTION
The call to updateToast wasn't updated after the api was updated by me. This caused the blank toast to show up

Before:
![image](https://user-images.githubusercontent.com/23544999/113774109-d97d8280-96f4-11eb-9625-f9cf4ccb0534.png)

After: 
![image](https://user-images.githubusercontent.com/23544999/113774161-e8643500-96f4-11eb-8190-ff2a81a93db3.png)
