### PR TITLE
FIX: Remove SwipeableRoutes in favor of Switch

### DIFF
--- a/apps/mull-ui/src/app/app.tsx
+++ b/apps/mull-ui/src/app/app.tsx
@@ -3,7 +3,6 @@ import axios from 'axios';
 import jwtDecode from 'jwt-decode';
 import React, { CSSProperties, useEffect, useState } from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
-import SwipeableRoutes from 'react-swipeable-routes';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.min.css';
 import { ROUTES } from '../constants';
@@ -97,14 +96,14 @@ export const App = () => {
               className="top-nav-bar-shadow"
             />
             <div className="page-container with-sub-nav-bar">
-              <SwipeableRoutes>
+              <Switch>
                 <PrivateRoute path={ROUTES.DISCOVER.url} component={DiscoverPage} />
                 <PrivateRoute path={ROUTES.UPCOMING.url} component={UpcomingPage} />
                 <PrivateRoute path={ROUTES.MY_EVENTS.url} component={MyEventsPage} />
-                <PrivateRoute exact path={ROUTES.HOME}>
+                <PrivateRoute path={ROUTES.HOME}>
                   <Redirect to={ROUTES.DISCOVER.url} />
                 </PrivateRoute>
-              </SwipeableRoutes>
+              </Switch>
             </div>
           </PrivateRoute>
           <PrivateRoute path={ROUTES.MESSAGES} component={MessagesRoute} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -6598,11 +6598,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
-    },
     "@sideway/address": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
@@ -12847,83 +12842,6 @@
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
           "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
           "dev": true
-        }
-      }
-    },
-    "dom-testing-library": {
-      "version": "3.19.4",
-      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.19.4.tgz",
-      "integrity": "sha512-GJOx8CLpnkvM3takILOsld/itUUc9+7Qh6caN1Spj6+9jIgNPY36fsvoH7sEgYokC0lBRdttO7G7fIFYCXlmcA==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "pretty-format": "^24.7.0",
-        "wait-for-expect": "^1.1.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
         }
       }
     },
@@ -22806,23 +22724,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-swipeable-routes": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/react-swipeable-routes/-/react-swipeable-routes-0.8.0.tgz",
-      "integrity": "sha512-4Lkm8pKfDfp6ZzsPTgzTmWlUyFW35QAy5YqcbH1Yfg8u805l1laUnG3wX+5mKRVrRav3TeEqxZ89iCXOO2FSmQ==",
-      "requires": {
-        "path-to-regexp": "^2.1.0",
-        "react-swipeable-views": "^0.13.9",
-        "react-testing-library": "^5.3.1"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
-        }
-      }
-    },
     "react-swipeable-views": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/react-swipeable-views/-/react-swipeable-views-0.13.9.tgz",
@@ -22924,15 +22825,6 @@
             "object-assign": "^4.1.1"
           }
         }
-      }
-    },
-    "react-testing-library": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-5.9.0.tgz",
-      "integrity": "sha512-T303PJZvrLKeeiPpjmMD1wxVpzEg9yI0qteH/cUvpFqNHOzPe3yN+Pu+jo9JlxuTMvVGPAmCAcgZ3sEtEDpJUQ==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "dom-testing-library": "^3.13.1"
       }
     },
     "react-toastify": {
@@ -27276,11 +27168,6 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
-    },
-    "wait-for-expect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
     },
     "wait-on": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-dom": "17.0.1",
     "react-nice-dates": "^3.1.0",
     "react-router-dom": "5.2.0",
-    "react-swipeable-routes": "^0.8.0",
     "react-swipeable-views": "^0.13.9",
     "react-toastify": "^6.0.9",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
closes #345 

Currently, on develop, if you go to any `/home/anything` route by either typing that in the URL box or history.push, you will be redirected to the discover page. This happens event on valid routes such as `/home/upcoming` and `/home/myevents`. This causes several issues:
- If you go to the myevents page, press on an event and then go back, you are faced with the discover page, which makes no sense and messes with the user flow
- If you need to history.push to either the upcoming or myevent pages in the code (like with [Yunshi's PR](#334), this *WILL NOT* work, since you will get redirected to the discover page
- As a user, you can't go directly to the upcoming and myevents pages. You have to start off at the discover page and then press/swipe your way to the other pages.

This is pretty bad. Is it caused by the SwipeableRoutes component. No matter not I adjust the 4th catch-all route which redirects to the discover page, the page won't work correctly. From reading their documentation, there isn't even an example with a catch-all base route: https://www.npmjs.com/package/react-swipeable-routes

```tsx
              <SwipeableRoutes>
                <PrivateRoute path={ROUTES.DISCOVER.url} component={DiscoverPage} />
                <PrivateRoute path={ROUTES.UPCOMING.url} component={UpcomingPage} />
                <PrivateRoute path={ROUTES.MY_EVENTS.url} component={MyEventsPage} />
                <PrivateRoute exact path={ROUTES.HOME}>
                  <Redirect to={ROUTES.DISCOVER.url} />
                </PrivateRoute>
              </SwipeableRoutes>
```

This is easily fixed with the changes in this PR. Instead of using SwipeableRoutes, we use a simple Switch. This fixes all the issues I listed. The downsides are that we can't swipe between the home pages, and there's no animation when you transition between the pages. I don't see this as a big deal.

Just a side note, this also ends up fixing the flakiness I had with the e2e for US-2.8, since that was caused by the SwipeableRoutes