### PR TITLE
TASK-87: Messages Page UX/Styling Cleanup

### DIFF
--- a/apps/mull-api/src/app/entities/post.entity.ts
+++ b/apps/mull-api/src/app/entities/post.entity.ts
@@ -1,3 +1,4 @@
+import { LIMITS } from '@mull/types';
 import { Field, Int, ObjectType } from '@nestjs/graphql';
 import {
   Column,
@@ -30,7 +31,7 @@ export class Post {
   parentPost?: Post;
 
   @Field()
-  @Column({ nullable: true })
+  @Column({ nullable: true, length: LIMITS.POST_MESSAGE })
   message: string;
 
   @Field()

--- a/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-1.1.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
 /// <reference types="Cypress" />
 import 'cypress-file-upload';
 import { geolocationStub } from '../fixtures';
@@ -74,7 +75,10 @@ frameSizes.forEach((frame) => {
     });
 
     it('should type into the event description input', () => {
-      cy.get('#description').type('test description').should('have.value', 'test description');
+      cy.get('#description')
+        .type('test description')
+        .wait(500)
+        .should('have.text', 'test description');
     });
 
     it('should type into the event location modal and return autocompleted address', () => {
@@ -112,16 +116,7 @@ frameSizes.forEach((frame) => {
 
     it('should show errors when fields are not completed', () => {
       cy.get('.create-event-button').click();
-      cy.get('.custom-file-upload-container > .error-message').should(
-        'have.text',
-        'Image is required.'
-      );
-      cy.get('#eventTitle ~ .error-message').should('have.text', 'Event Title is required.');
-      cy.get('.textarea-create-event-container > .error-message').should(
-        'have.text',
-        'Event Description is required.'
-      );
-      cy.get('#location ~ .error-message').should('have.text', 'Event Location is required.');
+      cy.get('.error-message').first().should('have.text', 'Image is required.');
     });
 
     const fillEventForm = () => {

--- a/apps/mull-ui-e2e/src/integration/US-3.1.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-3.1.spec.ts
@@ -13,7 +13,7 @@ frameSizes.forEach((frame) => {
       const date = new Date();
       cy.visit('http://localhost:4200/messages/event/1/announcements');
       cy.get('.event-chat', { timeout: 5000 }).should('exist');
-      cy.get('.custom-text-input').type(`${date.toString()}{enter}`);
+      cy.get('.mull-text-area').type(`${date.toString()}{enter}`);
       /* eslint-disable-next-line cypress/no-unnecessary-waiting */
       cy.wait(500); // Test was flaky with aliases
       cy.contains(date.toString());

--- a/apps/mull-ui-e2e/src/integration/US-3.2.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-3.2.spec.ts
@@ -13,7 +13,7 @@ frameSizes.forEach((frame) => {
       const date = new Date();
       cy.visit('http://localhost:4200/messages/event/1/group-chat');
       cy.get('.event-chat', { timeout: 5000 }).should('exist');
-      cy.get('.custom-text-input').type(`${date.toString()}{enter}`);
+      cy.get('.mull-text-area').type(`${date.toString()}{enter}`);
       /* eslint-disable-next-line cypress/no-unnecessary-waiting */
       cy.wait(500); // Test was flaky with aliases
       cy.contains(date.toString());

--- a/apps/mull-ui-e2e/src/integration/US-3.4.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-3.4.spec.ts
@@ -15,12 +15,12 @@ frameSizes.forEach((frame) => {
       cy.get('.user-information').first().click();
       cy.get('.direct-message-chat', { timeout: 5000 }).should('exist');
       const message = `Hello ${faker.random.number()}`;
-      cy.get('.custom-text-input').type(`${message}{enter}`);
+      cy.get('.mull-text-area').type(`${message}{enter}`);
       cy.contains(message, { timeout: 5000 });
 
       const imageText = `Image ${faker.random.number()}`;
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
-      cy.get('.custom-text-input').type(`${imageText}{enter}`);
+      cy.get('.mull-text-area').type(`${imageText}{enter}`);
       cy.contains(imageText, { timeout: 5000 });
     });
   });

--- a/apps/mull-ui-e2e/src/integration/US-3.5.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-3.5.spec.ts
@@ -15,7 +15,7 @@ frameSizes.forEach((frame) => {
       cy.get('.event-chat', { timeout: 5000 }).should('exist');
 
       cy.get('#imageFile').attachFile('../fixtures/trashed-park.jpg');
-      cy.get('.custom-text-input').type(`${text}{enter}`);
+      cy.get('.mull-text-area').type(`${text}{enter}`);
 
       cy.contains(text);
     });

--- a/apps/mull-ui/src/app/app.scss
+++ b/apps/mull-ui/src/app/app.scss
@@ -8,6 +8,10 @@
     margin: 0;
   }
 
+  &.no-bot-nav {
+    margin-bottom: 0;
+  }
+
   &.full-width {
     padding: 1rem 0;
   }

--- a/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.scss
@@ -1,6 +1,0 @@
-.chat-bubble-image {
-  max-width: 11rem;
-  max-height: 12rem;
-  display: block;
-  object-fit: contain;
-}

--- a/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble-list/chat-bubble-list.tsx
@@ -1,7 +1,7 @@
 import { ISerializedPost } from '@mull/types';
 import { History } from 'history';
 import React, { useContext, useEffect, useRef } from 'react';
-import { avatarUrl, formatChatBubbleDate, getMediaUrl } from '../../../utilities';
+import { formatChatBubbleDate, getMediaUrl } from '../../../utilities';
 import ChatBubble from '../../components/chat-bubble/chat-bubble';
 import UserContext from '../../context/user.context';
 import './chat-bubble-list.scss';
@@ -41,7 +41,7 @@ export const ChatBubbleList = ({ history, posts, subToMore }: ChatBubbleListProp
           key={post.id}
           isCurrentUser={userId === post.user.id}
           chatDate={formatChatBubbleDate(new Date(post.createdTime))}
-          userPicture={avatarUrl(post.user)}
+          user={post.user}
           onClick={() => {
             history.push(`/user/${post.user.id}`);
           }}

--- a/apps/mull-ui/src/app/components/chat-bubble/__snapshots__/chat-bubble.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-bubble/__snapshots__/chat-bubble.spec.tsx.snap
@@ -2,21 +2,28 @@
 
 exports[`ChatBubble should match snapshot 1`] = `
 <div
-  className="chat-container"
+  className="chat-bubble-container"
 >
-  <p
-    className="announcement-time"
+  <div
+    className="chat-bubble-header"
   >
-    
-  </p>
+    <p>
+      
+    </p>
+    <p
+      className="chat-bubble-header-username"
+    >
+      Bob
+    </p>
+  </div>
   <div
     className="other-user-chat-container"
   >
     <img
       alt="user"
-      className="user-picture"
+      className="user-picture button"
       onClick={null}
-      src=""
+      src="http://localhost:3333/api/media/1"
     />
     <p
       className="chat-bubble"

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -16,6 +16,7 @@
   max-height: 12rem;
   display: block;
   object-fit: contain;
+  border-radius: 0.8rem;
 }
 
 .current-user-chat-container {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -1,6 +1,7 @@
 @import '../../../variables.scss';
+@import '../../../mixins.scss';
 
-.chat-container {
+.chat-bubble-container {
   margin: 1rem 0;
 }
 
@@ -42,10 +43,18 @@
   }
 }
 
-.announcement-time {
+.chat-bubble-header {
+  display: flex;
+  position: relative;
   font-size: 0.875rem;
-  text-align: center;
   color: $inactive-button-color;
+  justify-content: center;
+}
+
+.chat-bubble-header-username {
+  position: absolute;
+  right: 0.25rem;
+  @include vertical-center-fixed;
 }
 
 .user-picture {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -47,15 +47,23 @@
 .chat-bubble-header {
   display: flex;
   position: relative;
-  font-size: 0.875rem;
   color: $inactive-button-color;
   justify-content: center;
+
+  * {
+    font-size: 0.8em;
+  }
 }
 
 .chat-bubble-header-username {
   position: absolute;
-  right: 0.25rem;
+  left: 0.25rem;
   @include vertical-center-fixed;
+
+  width: calc(50% - 4rem);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .user-picture {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -8,6 +8,7 @@
 .chat-bubble {
   max-width: 65%;
   overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .chat-bubble-image {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -9,6 +9,13 @@
   overflow-wrap: break-word;
 }
 
+.chat-bubble-image {
+  max-width: 11rem;
+  max-height: 12rem;
+  display: block;
+  object-fit: contain;
+}
+
 .current-user-chat-container {
   flex-direction: row-reverse;
   img {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.spec.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.spec.tsx
@@ -1,17 +1,18 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { mockUser1 } from '../../../mockdata';
 import ChatBubble from './chat-bubble';
 
 describe('ChatBubble', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<ChatBubble />);
+    const { baseElement } = render(<ChatBubble user={mockUser1} />);
 
     expect(baseElement).toBeTruthy();
   });
 
   it('should match snapshot', () => {
-    const tree = renderer.create(<ChatBubble />).toJSON();
+    const tree = renderer.create(<ChatBubble user={mockUser1} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
@@ -22,7 +22,7 @@ export const ChatBubble = ({
     <div className="chat-bubble-container">
       <div className="chat-bubble-header">
         <p>{chatDate}</p>
-        <p className="chat-bubble-header-username">{user.name}</p>
+        {!isCurrentUser ? <p className="chat-bubble-header-username">{user.name}</p> : null}
       </div>
       <div className={`${isCurrentUser ? 'current-user' : 'other-user'}-chat-container`}>
         <img className="user-picture button" src={avatarUrl(user)} alt="user" onClick={onClick} />

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
@@ -25,7 +25,7 @@ export const ChatBubble = ({
         <p className="chat-bubble-header-username">{user.name}</p>
       </div>
       <div className={`${isCurrentUser ? 'current-user' : 'other-user'}-chat-container`}>
-        <img className="user-picture" src={avatarUrl(user)} alt="user" onClick={onClick} />
+        <img className="user-picture button" src={avatarUrl(user)} alt="user" onClick={onClick} />
         <p className="chat-bubble">{children}</p>
       </div>
     </div>

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
@@ -1,10 +1,12 @@
+import { User } from 'apps/mull-ui/src/generated/graphql';
+import { avatarUrl } from 'apps/mull-ui/src/utilities';
 import React, { ReactChild } from 'react';
 import './chat-bubble.scss';
 
 export interface chatBubbleProps {
   isCurrentUser?: boolean;
   chatDate?: string;
-  userPicture?: string;
+  user: Partial<User>;
   children?: ReactChild;
   onClick?: React.MouseEventHandler<HTMLImageElement>;
 }
@@ -12,15 +14,18 @@ export interface chatBubbleProps {
 export const ChatBubble = ({
   isCurrentUser = false,
   chatDate = '',
-  userPicture = '',
+  user,
   children = '',
   onClick = null,
 }: chatBubbleProps) => {
   return (
-    <div className="chat-container">
-      <p className="announcement-time">{chatDate}</p>
+    <div className="chat-bubble-container">
+      <div className="chat-bubble-header">
+        <p>{chatDate}</p>
+        <p className="chat-bubble-header-username">{user.name}</p>
+      </div>
       <div className={`${isCurrentUser ? 'current-user' : 'other-user'}-chat-container`}>
-        <img className="user-picture" src={userPicture} alt="user" onClick={onClick} />
+        <img className="user-picture" src={avatarUrl(user)} alt="user" onClick={onClick} />
         <p className="chat-bubble">{children}</p>
       </div>
     </div>

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.tsx
@@ -1,6 +1,6 @@
-import { User } from 'apps/mull-ui/src/generated/graphql';
-import { avatarUrl } from 'apps/mull-ui/src/utilities';
 import React, { ReactChild } from 'react';
+import { User } from '../../../generated/graphql';
+import { avatarUrl } from '../../../utilities';
 import './chat-bubble.scss';
 
 export interface chatBubbleProps {

--- a/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
@@ -3,11 +3,13 @@
 exports[`ChatInput should match snapshot 1`] = `
 <div
   className="chat-input-container"
+  id="chat-input-container"
 >
   <form
     autoComplete="off"
     className="chat-input-form"
     data-testid="chat-input"
+    id="chat-input-form"
     onSubmit={[MockFunction]}
   >
     <div
@@ -52,7 +54,7 @@ exports[`ChatInput should match snapshot 1`] = `
     >
       <label
         className="mull-text-area-label"
-        htmlFor="message"
+        htmlFor="chat-input-textarea"
       >
         
       </label>
@@ -63,7 +65,7 @@ exports[`ChatInput should match snapshot 1`] = `
           className="mull-text-area input-border "
           contentEditable={true}
           data-testid="mull-text-area"
-          id="message"
+          id="chat-input-textarea"
           onInput={[Function]}
           role="textbox"
           suppressContentEditableWarning={true}

--- a/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
@@ -66,11 +66,6 @@ exports[`ChatInput should match snapshot 1`] = `
           id="message"
           onInput={[Function]}
           role="textbox"
-          style={
-            Object {
-              "whiteSpace": "pre-wrap",
-            }
-          }
           suppressContentEditableWarning={true}
         />
         <div
@@ -78,7 +73,8 @@ exports[`ChatInput should match snapshot 1`] = `
         >
           <button
             className="chat-input-button"
-            type="submit"
+            onClick={[Function]}
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -101,7 +97,6 @@ exports[`ChatInput should match snapshot 1`] = `
         </div>
       </div>
     </div>
-     
   </form>
 </div>
 `;

--- a/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`ChatInput should match snapshot 1`] = `
   className="chat-input-container"
 >
   <form
+    autoComplete="off"
     className="chat-input-form"
     data-testid="chat-input"
     onSubmit={[MockFunction]}
@@ -17,7 +18,7 @@ exports[`ChatInput should match snapshot 1`] = `
         htmlFor="imageFile"
       >
         <div
-          className="file-upload-feedback"
+          className="button file-upload-feedback"
         >
           <svg
             aria-hidden="true"
@@ -47,45 +48,60 @@ exports[`ChatInput should match snapshot 1`] = `
       />
     </div>
     <div
-      className="custom-text-input-container "
+      className="mull-text-area-container "
     >
       <label
-        className="custom-text-input-label"
+        className="mull-text-area-label"
         htmlFor="message"
       >
         
       </label>
-      <input
-        autoComplete="off"
-        className="custom-text-input input-border "
-        data-testid="custom-text-input"
-        id="message"
-        name="message"
-        type="text"
-      />
-      <button
-        className="chat-input-button"
-        type="submit"
+      <div
+        className="mull-text-area-sub-container grow-wrap"
       >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-paper-plane fa-w-16 send-icon"
-          data-icon="paper-plane"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className="mull-text-area input-border "
+          contentEditable={true}
+          data-testid="mull-text-area"
+          id="message"
+          onInput={[Function]}
+          role="textbox"
+          style={
+            Object {
+              "whiteSpace": "pre-wrap",
+            }
+          }
+          suppressContentEditableWarning={true}
+        />
+        <div
+          className="mull-text-area-icon"
         >
-          <path
-            d="M476 3.2L12.5 270.6c-18.1 10.4-15.8 35.6 2.2 43.2L121 358.4l287.3-253.2c5.5-4.9 13.3 2.6 8.6 8.3L176 407v80.5c0 23.6 28.5 32.9 42.5 15.8L282 426l124.6 52.2c14.2 6 30.4-2.9 33-18.2l72-432C515 7.8 493.3-6.8 476 3.2z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-      </button>
+          <button
+            className="chat-input-button"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-paper-plane fa-w-16 "
+              data-icon="paper-plane"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M476 3.2L12.5 270.6c-18.1 10.4-15.8 35.6 2.2 43.2L121 358.4l287.3-253.2c5.5-4.9 13.3 2.6 8.6 8.3L176 407v80.5c0 23.6 28.5 32.9 42.5 15.8L282 426l124.6 52.2c14.2 6 30.4-2.9 33-18.2l72-432C515 7.8 493.3-6.8 476 3.2z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
     </div>
+     
   </form>
 </div>
 `;

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -69,6 +69,10 @@
   }
 }
 
+.error-max-chat {
+  color: red;
+}
+
 @media (min-width: $breakpoint-mobile) {
   .chat-input-container {
     width: $page-container-width;

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -56,6 +56,19 @@
   margin-right: 0.5rem;
 }
 
+.chat-input-limit-message {
+  font-size: 0.7rem;
+  position: absolute;
+  right: 1.4rem;
+  bottom: 1.4rem;
+}
+
+.chat-input-form {
+  .mull-text-area {
+    padding-right: 3.2rem !important;
+  }
+}
+
 @media (min-width: $breakpoint-mobile) {
   .chat-input-container {
     width: $page-container-width;

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -21,13 +21,11 @@
     width: 100%;
   }
   .chat-input-button {
-    position: absolute;
-    bottom: 0.4rem;
-    right: 0.5rem;
+    position: relative;
+    left: 0.5rem;
     width: 2rem;
     height: 2rem;
     border-radius: 100%;
-    border: 1px $primary-color solid;
     background: $primary-color;
     box-sizing: border-box;
     padding: 0.3em;
@@ -64,5 +62,6 @@
     margin-left: auto;
     margin-right: auto;
     bottom: 0;
+    padding: 1rem 0;
   }
 }

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -50,9 +50,12 @@
   }
 }
 
-.chat-input-image-size {
+.chat-input-image {
+  object-fit: contain;
   max-height: 3rem;
-  max-width: 9rem;
+  max-width: 8rem;
+  border-radius: 10px;
+  margin-right: 0.5rem;
 }
 
 @media (min-width: $breakpoint-mobile) {

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -81,4 +81,8 @@
     bottom: 0;
     padding: 1rem 0;
   }
+
+  .chat-input-limit-message {
+    right: 0.4rem;
+  }
 }

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.spec.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.spec.tsx
@@ -4,10 +4,10 @@ import renderer from 'react-test-renderer';
 import ChatInput from './chat-input';
 
 const mockFormik = {
-  values: { location: 'test string' },
-  setFieldValue: { location: 'value' },
-  touched: { location: false },
-  errors: { location: false },
+  values: { message: 'test string', imageFile: '' },
+  setFieldValue: jest.fn(),
+  touched: { message: false, imageFile: false },
+  errors: { message: '', imageFile: '' },
   handleSubmit: jest.fn(),
 };
 

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -11,6 +11,7 @@ export interface ChatInputProps {
   formik: FormikContextType<IChatForm> & {
     setFieldValue: (
       field: string,
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       value: any,
       shouldValidate?: boolean
     ) => Promise<void> | Promise<FormikErrors<IChatForm>>;
@@ -33,7 +34,7 @@ export const ChatInput = ({
   const inputRef = useRef<HTMLDivElement>(null);
 
   const onKeyPress = (e: KeyboardEvent) => {
-    if (e.code == 'Enter' && !e.shiftKey) {
+    if (e.code === 'Enter' && !e.shiftKey) {
       formik.submitForm();
       setTimeout(() => {
         inputRef.current.innerText = '';
@@ -42,12 +43,13 @@ export const ChatInput = ({
   };
 
   useEffect(() => {
-    if (inputRef) {
-      inputRef.current.addEventListener('keydown', onKeyPress);
-    }
+    const localInputRef = inputRef.current;
+    inputRef.current.addEventListener('keydown', onKeyPress);
+
     return () => {
-      inputRef.current.removeEventListener('keydown', onKeyPress);
+      localInputRef.removeEventListener('keydown', onKeyPress);
     };
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
   return (

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -18,6 +18,8 @@ export interface ChatInputProps {
   image?: string;
   handleFileUpload?: (event: ChangeEvent<HTMLInputElement>) => void;
   handleCloseImage?: MouseEventHandler<HTMLImageElement>;
+  onFocus?: React.FocusEventHandler<HTMLDivElement>;
+  onBlur?: React.FocusEventHandler<HTMLDivElement>;
 }
 
 export const ChatInput = ({
@@ -25,6 +27,8 @@ export const ChatInput = ({
   image,
   handleFileUpload,
   handleCloseImage,
+  onFocus,
+  onBlur,
 }: ChatInputProps) => {
   const inputRef = useRef<HTMLDivElement>(null);
 
@@ -80,6 +84,8 @@ export const ChatInput = ({
           onChange={(e) => {
             formik.setFieldValue('message', e.target.textContent);
           }}
+          onFocus={onFocus}
+          onBlur={onBlur}
           hasErrors={null}
           errorMessage={null}
           autoComplete="off"

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -22,8 +22,13 @@ export const ChatInput = ({
 }: ChatInputProps) => {
   return (
     <div className="chat-input-container">
-      {formik.touched.imageFile && !!formik.errors.imageFile ? (
-        <span className="error-message">{formik.errors.imageFile}</span>
+      {(formik.touched.imageFile && !!formik.errors.imageFile) ||
+      (formik.touched.message && !!formik.errors.message) ? (
+        <span className="error-message">
+          {`${formik.errors.message ? formik.errors.message : ''} ${
+            formik.errors.imageFile ? formik.errors.imageFile : ''
+          }`}
+        </span>
       ) : null}
       <form
         className="chat-input-form"
@@ -32,7 +37,7 @@ export const ChatInput = ({
         autoComplete="off"
       >
         {image && (
-          <img className="chat-input-image-size" src={image} alt="" onClick={handleCloseImage} />
+          <img className="chat-input-image" src={image} alt="" onClick={handleCloseImage} />
         )}
         <CustomFileUpload
           className="file-upload-feedback"

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -19,8 +19,8 @@ export interface ChatInputProps {
   image?: string;
   handleFileUpload?: (event: ChangeEvent<HTMLInputElement>) => void;
   handleCloseImage?: MouseEventHandler<HTMLImageElement>;
-  onFocus?: React.FocusEventHandler<HTMLDivElement>;
-  onBlur?: React.FocusEventHandler<HTMLDivElement>;
+  onFocus?: React.FocusEventHandler<HTMLFormElement>;
+  onBlur?: React.FocusEventHandler<HTMLFormElement>;
 }
 
 export const ChatInput = ({
@@ -39,11 +39,16 @@ export const ChatInput = ({
   };
 
   const onSubmit = async () => {
-    await formik.submitForm();
     if (/^\s*$/.test(formik.values.message) || !formik.errors.message) {
-      formik.setFieldValue('message', '');
       inputRef.current.textContent = '';
+      await formik.submitForm();
+      formik.setFieldValue('message', '');
+    } else {
+      await formik.submitForm();
     }
+    setTimeout(() => {
+      onBlur(null);
+    }, 50);
   };
 
   useEffect(() => {
@@ -57,12 +62,15 @@ export const ChatInput = ({
   }, []);
 
   return (
-    <div className="chat-input-container">
+    <div className="chat-input-container" id="chat-input-container">
       <form
+        id="chat-input-form"
         className="chat-input-form"
         onSubmit={formik.handleSubmit}
         data-testid="chat-input"
         autoComplete="off"
+        onFocus={onFocus}
+        onBlur={onBlur}
       >
         {image && (
           <img className="chat-input-image" src={image} alt="" onClick={handleCloseImage} />
@@ -78,22 +86,19 @@ export const ChatInput = ({
         <MullTextArea
           inputRef={inputRef}
           title=""
-          fieldName="message"
+          fieldName="chat-input-textarea"
           onInput={(e) => {
             const target = e.target as HTMLDivElement;
 
-            formik.setFieldValue('message', (e.target as HTMLDivElement).textContent);
+            formik.setFieldValue('message', target.textContent);
 
             // User tried to submit form
             if (lastKeyEventRef.current.key === 'Enter' && !lastKeyEventRef.current.shiftKey) {
               onSubmit();
             }
           }}
-          onFocus={onFocus}
-          onBlur={onBlur}
           hasErrors={null}
           errorMessage={null}
-          autoComplete="off"
           svgIcon={
             <button type="button" className="chat-input-button" onClick={onSubmit}>
               <FontAwesomeIcon icon={faPaperPlane} />

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -38,6 +38,14 @@ export const ChatInput = ({
     lastKeyEventRef.current = e;
   };
 
+  const onSubmit = async () => {
+    await formik.submitForm();
+    if (/^\s*$/.test(formik.values.message) || !formik.errors.message) {
+      formik.setFieldValue('message', '');
+      inputRef.current.textContent = '';
+    }
+  };
+
   useEffect(() => {
     const localInputRef = inputRef.current;
     inputRef.current.addEventListener('keydown', onKeyDown);
@@ -78,8 +86,7 @@ export const ChatInput = ({
 
             // User tried to submit form
             if (lastKeyEventRef.current.key === 'Enter' && !lastKeyEventRef.current.shiftKey) {
-              target.textContent = '';
-              formik.submitForm();
+              onSubmit();
             }
           }}
           onFocus={onFocus}
@@ -88,16 +95,18 @@ export const ChatInput = ({
           errorMessage={null}
           autoComplete="off"
           svgIcon={
-            <button type="submit" className="chat-input-button">
+            <button type="button" className="chat-input-button" onClick={onSubmit}>
               <FontAwesomeIcon icon={faPaperPlane} />
             </button>
           }
         />
         {LIMITS.POST_MESSAGE - formik.values.message.length < 100 ? (
-          <div className="chat-input-limit-message">
+          <div
+            className={`chat-input-limit-message ${formik.errors.message ? 'error-max-chat' : ''}`}
+          >
             {LIMITS.POST_MESSAGE - formik.values.message.length}/{LIMITS.POST_MESSAGE}
           </div>
-        ) : null}{' '}
+        ) : null}
       </form>
     </div>
   );

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -4,11 +4,13 @@ import { IChatForm } from '@mull/types';
 import { FormikContextType } from 'formik';
 import React, { ChangeEvent, MouseEventHandler } from 'react';
 import CustomFileUpload from '../custom-file-upload/custom-file-upload';
-import CustomTextInput from '../custom-text-input/custom-text-input';
+import MullTextArea from '../mull-text-area/mull-text-area';
 import './chat-input.scss';
 
 export interface ChatInputProps {
-  formik: FormikContextType<IChatForm>;
+  formik: FormikContextType<IChatForm> & {
+    setFieldValue: (field: string, value: any, shouldValidate?: boolean) => Promise<void>;
+  };
   image?: string;
   handleFileUpload?: (event: ChangeEvent<HTMLInputElement>) => void;
   handleCloseImage?: MouseEventHandler<HTMLImageElement>;
@@ -47,17 +49,20 @@ export const ChatInput = ({
           handleFileUpload={handleFileUpload}
           fieldName="imageFile"
         />
-        <CustomTextInput
+
+        <MullTextArea
           title=""
           fieldName="message"
-          value={formik.values.message}
-          onChange={formik.handleChange}
+          onChange={(e) => {
+            formik.setFieldValue('message', e.target.textContent);
+            console.log(e.target.textContent);
+          }}
           hasErrors={null}
           errorMessage={null}
           autoComplete="off"
           svgIcon={
             <button type="submit" className="chat-input-button">
-              <FontAwesomeIcon icon={faPaperPlane} className="send-icon" />
+              <FontAwesomeIcon icon={faPaperPlane} />
             </button>
           }
         />

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -32,36 +32,24 @@ export const ChatInput = ({
   onBlur,
 }: ChatInputProps) => {
   const inputRef = useRef<HTMLDivElement>(null);
+  const lastKeyEventRef = useRef<KeyboardEvent>();
 
-  const onKeyPress = (e: KeyboardEvent) => {
-    if (e.code === 'Enter' && !e.shiftKey) {
-      formik.submitForm();
-      setTimeout(() => {
-        inputRef.current.innerText = '';
-      }, 100);
-    }
+  const onKeyDown = (e: KeyboardEvent) => {
+    lastKeyEventRef.current = e;
   };
 
   useEffect(() => {
     const localInputRef = inputRef.current;
-    inputRef.current.addEventListener('keydown', onKeyPress);
+    inputRef.current.addEventListener('keydown', onKeyDown);
 
     return () => {
-      localInputRef.removeEventListener('keydown', onKeyPress);
+      localInputRef.removeEventListener('keydown', onKeyDown);
     };
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
   return (
     <div className="chat-input-container">
-      {(formik.touched.imageFile && !!formik.errors.imageFile) ||
-      (formik.touched.message && !!formik.errors.message) ? (
-        <span className="error-message">
-          {`${formik.errors.message ? formik.errors.message : ''} ${
-            formik.errors.imageFile ? formik.errors.imageFile : ''
-          }`}
-        </span>
-      ) : null}
       <form
         className="chat-input-form"
         onSubmit={formik.handleSubmit}
@@ -83,8 +71,16 @@ export const ChatInput = ({
           inputRef={inputRef}
           title=""
           fieldName="message"
-          onChange={(e) => {
-            formik.setFieldValue('message', e.target.textContent);
+          onInput={(e) => {
+            const target = e.target as HTMLDivElement;
+
+            formik.setFieldValue('message', (e.target as HTMLDivElement).textContent);
+
+            // User tried to submit form
+            if (lastKeyEventRef.current.key === 'Enter' && !lastKeyEventRef.current.shiftKey) {
+              target.textContent = '';
+              formik.submitForm();
+            }
           }}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -1,15 +1,19 @@
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IChatForm } from '@mull/types';
-import { FormikContextType } from 'formik';
-import React, { ChangeEvent, MouseEventHandler } from 'react';
+import { FormikContextType, FormikErrors } from 'formik';
+import React, { ChangeEvent, MouseEventHandler, useEffect, useRef } from 'react';
 import CustomFileUpload from '../custom-file-upload/custom-file-upload';
 import MullTextArea from '../mull-text-area/mull-text-area';
 import './chat-input.scss';
 
 export interface ChatInputProps {
   formik: FormikContextType<IChatForm> & {
-    setFieldValue: (field: string, value: any, shouldValidate?: boolean) => Promise<void>;
+    setFieldValue: (
+      field: string,
+      value: any,
+      shouldValidate?: boolean
+    ) => Promise<void> | Promise<FormikErrors<IChatForm>>;
   };
   image?: string;
   handleFileUpload?: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -22,6 +26,26 @@ export const ChatInput = ({
   handleFileUpload,
   handleCloseImage,
 }: ChatInputProps) => {
+  const inputRef = useRef<HTMLDivElement>(null);
+
+  const onKeyPress = (e: KeyboardEvent) => {
+    if (e.code == 'Enter' && !e.shiftKey) {
+      formik.submitForm();
+      setTimeout(() => {
+        inputRef.current.innerText = '';
+      }, 100);
+    }
+  };
+
+  useEffect(() => {
+    if (inputRef) {
+      inputRef.current.addEventListener('keydown', onKeyPress);
+    }
+    return () => {
+      inputRef.current.removeEventListener('keydown', onKeyPress);
+    };
+  }, []);
+
   return (
     <div className="chat-input-container">
       {(formik.touched.imageFile && !!formik.errors.imageFile) ||
@@ -51,11 +75,11 @@ export const ChatInput = ({
         />
 
         <MullTextArea
+          inputRef={inputRef}
           title=""
           fieldName="message"
           onChange={(e) => {
             formik.setFieldValue('message', e.target.textContent);
-            console.log(e.target.textContent);
           }}
           hasErrors={null}
           errorMessage={null}

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -1,6 +1,6 @@
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IChatForm } from '@mull/types';
+import { IChatForm, LIMITS } from '@mull/types';
 import { FormikContextType, FormikErrors } from 'formik';
 import React, { ChangeEvent, MouseEventHandler, useEffect, useRef } from 'react';
 import CustomFileUpload from '../custom-file-upload/custom-file-upload';
@@ -73,7 +73,6 @@ export const ChatInput = ({
           handleFileUpload={handleFileUpload}
           fieldName="imageFile"
         />
-
         <MullTextArea
           inputRef={inputRef}
           title=""
@@ -90,6 +89,11 @@ export const ChatInput = ({
             </button>
           }
         />
+        {LIMITS.POST_MESSAGE - formik.values.message.length < 100 ? (
+          <div className="chat-input-limit-message">
+            {LIMITS.POST_MESSAGE - formik.values.message.length}/{LIMITS.POST_MESSAGE}
+          </div>
+        ) : null}{' '}
       </form>
     </div>
   );

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -25,7 +25,12 @@ export const ChatInput = ({
       {formik.touched.imageFile && !!formik.errors.imageFile ? (
         <span className="error-message">{formik.errors.imageFile}</span>
       ) : null}
-      <form className="chat-input-form" onSubmit={formik.handleSubmit} data-testid="chat-input">
+      <form
+        className="chat-input-form"
+        onSubmit={formik.handleSubmit}
+        data-testid="chat-input"
+        autoComplete="off"
+      >
         {image && (
           <img className="chat-input-image-size" src={image} alt="" onClick={handleCloseImage} />
         )}

--- a/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
+++ b/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
@@ -33,7 +33,7 @@ export const CustomFileUpload = ({
           </div>
         )}
         {displayPencilIcon && (
-          <FontAwesomeIcon className="custom-file-upload-pencil-icon" icon={faPencilAlt} />
+          <FontAwesomeIcon className="custom-file-upload-pencil-icon button" icon={faPencilAlt} />
         )}
       </label>
       {hasErrors ? <span className="error-message">{errorMessage}</span> : null}

--- a/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
+++ b/apps/mull-ui/src/app/components/custom-file-upload/custom-file-upload.tsx
@@ -28,7 +28,7 @@ export const CustomFileUpload = ({
         {imageURL ? (
           <img className="custom-file-upload-image" src={imageURL} alt="Event" />
         ) : (
-          <div className={className}>
+          <div className={`button ${className}`}>
             <FontAwesomeIcon className="custom-file-upload-icon" icon={faImages} />
           </div>
         )}

--- a/apps/mull-ui/src/app/components/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
@@ -10,15 +10,22 @@ exports[`CustomTextInput should match snapshot 1`] = `
   >
     Text
   </label>
-  <input
-    className="custom-text-input input-border error"
-    data-testid="custom-text-input"
-    id="text"
-    name="text"
-    onChange={[MockFunction]}
-    type="text"
-    value=""
-  />
+  <div
+    className="custom-text-input-sub-container"
+  >
+    <input
+      className="custom-text-input input-border error"
+      data-testid="custom-text-input"
+      id="text"
+      name="text"
+      onChange={[MockFunction]}
+      type="text"
+      value=""
+    />
+    <div
+      className="custom-text-input-icon"
+    />
+  </div>
   <span
     className="error-message"
   >

--- a/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
+++ b/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
@@ -8,7 +8,7 @@ export interface CustomTextInputProps {
   errorMessage?: string;
   hasErrors?: boolean;
   svgIcon?: ReactNode;
-  password?: boolean;
+  type?: 'text' | 'password' | 'email';
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
@@ -40,7 +40,7 @@ export const CustomTextInput = ({
   hasErrors = false,
   errorMessage = null,
   svgIcon,
-  password,
+  type = 'text',
   onClick,
   readOnly,
   placeholder,
@@ -51,20 +51,22 @@ export const CustomTextInput = ({
       <label className="custom-text-input-label" htmlFor={fieldName}>
         {title}
       </label>
-      <input
-        className={`custom-text-input input-border ${hasErrors ? 'error' : ''}`}
-        id={fieldName}
-        name={fieldName}
-        data-testid="custom-text-input"
-        type={password ? 'password' : 'text'}
-        value={value}
-        onChange={onChange}
-        onClick={onClick}
-        readOnly={readOnly}
-        placeholder={placeholder}
-        autoComplete={autoComplete}
-      />
-      {svgIcon ? svgIcon : null}
+      <div className="custom-text-input-sub-container">
+        <input
+          className={`custom-text-input input-border ${hasErrors ? 'error' : ''}`}
+          id={fieldName}
+          name={fieldName}
+          data-testid="custom-text-input"
+          type={type}
+          value={value}
+          onChange={onChange}
+          onClick={onClick}
+          readOnly={readOnly}
+          placeholder={placeholder}
+          autoComplete={autoComplete}
+        />
+        <div className="custom-text-input-icon">{svgIcon ? svgIcon : null}</div>
+      </div>
       {hasErrors ? <span className="error-message">{errorMessage}</span> : null}
     </div>
   );

--- a/apps/mull-ui/src/app/components/index.ts
+++ b/apps/mull-ui/src/app/components/index.ts
@@ -13,6 +13,7 @@ export * from './modal/friend-modal/friend-modal';
 export * from './modal/mull-modal/mull-modal';
 export * from './mull-back-button/mull-back-button';
 export * from './mull-button/mull-button';
+export * from './mull-text-area/mull-text-area';
 export * from './navigation/bot-nav-bar/bot-nav-bar';
 export * from './navigation/nav-buttons/nav-buttons';
 export * from './navigation/sub-nav-bar/chat-header';

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
@@ -29,7 +29,7 @@
   display: block;
   outline: none;
   box-sizing: border-box;
-  padding: 0.7rem 2.5em 0.7rem 1rem;
+  padding: 0.7rem 3em 0.7rem 1rem;
   width: 100%;
   max-width: 100%;
   max-height: 8rem;

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
@@ -25,8 +25,7 @@
   line-height: 1.5;
 }
 
-.mull-text-area,
-.grow-wrap::after {
+.mull-text-area {
   display: block;
   outline: none;
   box-sizing: border-box;
@@ -35,4 +34,5 @@
   max-width: 100%;
   max-height: 8rem;
   overflow: auto;
+  word-break: break-all;
 }

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
@@ -1,37 +1,38 @@
 @import '../../../variables.scss';
 @import '../../../mixins.scss';
 
-.custom-text-input-container {
+.mull-text-area-container {
   position: relative;
   align-self: center;
   justify-self: center;
   width: 100%;
 }
 
-.custom-text-input-sub-container {
+.mull-text-area-sub-container {
   position: relative;
 }
 
-.custom-text-input-icon {
+.mull-text-area-icon {
   position: absolute;
   @include vertical-center-fixed;
   right: 1rem;
 }
 
-.custom-text-input-label {
+.mull-text-area-label {
   color: black;
   align-items: flex-start;
   font-weight: 600;
   line-height: 1.5;
 }
 
-.custom-text-input {
+.mull-text-area,
+.grow-wrap::after {
   display: block;
-  box-sizing: border-box;
   outline: none;
-  padding-left: 1em;
+  box-sizing: border-box;
+  padding: 0.7rem 2.5em 0.7rem 1rem;
   width: 100%;
-  height: 2.8em;
-  padding-right: 2.5em;
-  margin-top: 0.5rem;
+  max-width: 100%;
+  max-height: 8rem;
+  overflow: auto;
 }

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.scss
@@ -35,4 +35,5 @@
   max-height: 8rem;
   overflow: auto;
   word-break: break-all;
+  white-space: pre-line;
 }

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.spec.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import MullTextArea from './mull-text-area';
+
+describe('MullTextArea', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<MullTextArea />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -10,6 +10,8 @@ export interface MullTextAreaProps {
   svgIcon?: ReactNode;
   onChange?: (event: ChangeEvent<HTMLDivElement>) => void;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onFocus?: React.FocusEventHandler<HTMLDivElement>;
+  onBlur?: React.FocusEventHandler<HTMLDivElement>;
   placeholder?: string;
 }
 
@@ -17,11 +19,13 @@ export function MullTextArea({
   inputRef,
   title,
   fieldName,
-  onChange,
   hasErrors = false,
   errorMessage = null,
   svgIcon,
+  onChange,
   onClick,
+  onFocus,
+  onBlur,
   placeholder,
 }: MullTextAreaProps) {
   const grower = useRef<HTMLDivElement>(null);
@@ -43,6 +47,8 @@ export function MullTextArea({
           contentEditable={true}
           suppressContentEditableWarning={true}
           role="textbox"
+          onFocus={onFocus}
+          onBlur={onBlur}
         />
         <div className="mull-text-area-icon">{svgIcon ? svgIcon : null}</div>
       </div>

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -1,0 +1,51 @@
+import React, { ChangeEvent, ReactNode, useRef } from 'react';
+import './mull-text-area.scss';
+
+export interface MullTextAreaProps {
+  title: string;
+  fieldName: string;
+  errorMessage?: string;
+  hasErrors?: boolean;
+  svgIcon?: ReactNode;
+  onChange?: (event: ChangeEvent<HTMLDivElement>) => void;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  placeholder?: string;
+}
+
+export function MullTextArea({
+  title,
+  fieldName,
+  onChange,
+  hasErrors = false,
+  errorMessage = null,
+  svgIcon,
+  onClick,
+  placeholder,
+}: MullTextAreaProps) {
+  const grower = useRef<HTMLDivElement>(null);
+  return (
+    <div className={`mull-text-area-container ${hasErrors ? 'error' : ''}`}>
+      <label className="mull-text-area-label" htmlFor={fieldName}>
+        {title}
+      </label>
+      <div className="mull-text-area-sub-container grow-wrap" ref={grower}>
+        <div
+          style={{ whiteSpace: 'pre-wrap' }}
+          className={`mull-text-area input-border ${hasErrors ? 'error' : ''}`}
+          id={fieldName}
+          data-testid="mull-text-area"
+          onInput={onChange}
+          onClick={onClick}
+          placeholder={placeholder}
+          contentEditable={true}
+          suppressContentEditableWarning={true}
+          role="textbox"
+        />
+        <div className="mull-text-area-icon">{svgIcon ? svgIcon : null}</div>
+      </div>
+      {hasErrors ? <span className="error-message">{errorMessage}</span> : null}
+    </div>
+  );
+}
+
+export default MullTextArea;

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -41,7 +41,6 @@ export function MullTextArea({
       <div className="mull-text-area-sub-container grow-wrap" ref={grower}>
         <div
           ref={inputRef}
-          style={{ whiteSpace: 'pre-wrap' }}
           className={`mull-text-area input-border ${hasErrors ? 'error' : ''}`}
           id={fieldName}
           data-testid="mull-text-area"

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -30,7 +30,11 @@ export function MullTextArea({
 }: MullTextAreaProps) {
   const grower = useRef<HTMLDivElement>(null);
   return (
-    <div className={`mull-text-area-container ${hasErrors ? 'error' : ''}`}>
+    <div
+      className={`mull-text-area-container ${hasErrors ? 'error' : ''}`}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
       <label className="mull-text-area-label" htmlFor={fieldName}>
         {title}
       </label>
@@ -47,8 +51,6 @@ export function MullTextArea({
           contentEditable={true}
           suppressContentEditableWarning={true}
           role="textbox"
-          onFocus={onFocus}
-          onBlur={onBlur}
         />
         <div className="mull-text-area-icon">{svgIcon ? svgIcon : null}</div>
       </div>

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, ReactNode, useRef } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import './mull-text-area.scss';
 
 export interface MullTextAreaProps {
@@ -8,7 +8,7 @@ export interface MullTextAreaProps {
   errorMessage?: string;
   hasErrors?: boolean;
   svgIcon?: ReactNode;
-  onChange?: (event: ChangeEvent<HTMLDivElement>) => void;
+  onInput?: React.FormEventHandler<HTMLDivElement>;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
@@ -22,7 +22,7 @@ export function MullTextArea({
   hasErrors = false,
   errorMessage = null,
   svgIcon,
-  onChange,
+  onInput,
   onClick,
   onFocus,
   onBlur,
@@ -45,7 +45,7 @@ export function MullTextArea({
           className={`mull-text-area input-border ${hasErrors ? 'error' : ''}`}
           id={fieldName}
           data-testid="mull-text-area"
-          onInput={onChange}
+          onInput={onInput}
           onClick={onClick}
           placeholder={placeholder}
           contentEditable={true}

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, ReactNode, useRef } from 'react';
 import './mull-text-area.scss';
 
 export interface MullTextAreaProps {
+  inputRef?: React.MutableRefObject<HTMLDivElement>;
   title: string;
   fieldName: string;
   errorMessage?: string;
@@ -13,6 +14,7 @@ export interface MullTextAreaProps {
 }
 
 export function MullTextArea({
+  inputRef,
   title,
   fieldName,
   onChange,
@@ -30,6 +32,7 @@ export function MullTextArea({
       </label>
       <div className="mull-text-area-sub-container grow-wrap" ref={grower}>
         <div
+          ref={inputRef}
           style={{ whiteSpace: 'pre-wrap' }}
           className={`mull-text-area input-border ${hasErrors ? 'error' : ''}`}
           id={fieldName}

--- a/apps/mull-ui/src/app/hooks/useForceUpdate.ts
+++ b/apps/mull-ui/src/app/hooks/useForceUpdate.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 export const useForceUpdate = () => {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const [value, setValue] = useState(0); // integer state
   return () => setValue((value) => value + 1); // update the state to force render
 };

--- a/apps/mull-ui/src/app/hooks/useForceUpdate.ts
+++ b/apps/mull-ui/src/app/hooks/useForceUpdate.ts
@@ -1,0 +1,6 @@
+import { useState } from 'react';
+
+export const useForceUpdate = () => {
+  const [value, setValue] = useState(0); // integer state
+  return () => setValue((value) => value + 1); // update the state to force render
+};

--- a/apps/mull-ui/src/app/pages/create-event/create-event.scss
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.scss
@@ -5,8 +5,10 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  .custom-text-input-container {
-    margin-top: 1.875rem;
+  .custom-text-input-container,
+  .mull-text-area-container,
+  .pill-options-container {
+    margin-top: 1.5rem;
     width: 100%;
   }
   .custom-file-upload-container label {
@@ -58,13 +60,6 @@
     align-self: flex-start;
   }
 
-  .description-input-icon {
-    position: absolute;
-    right: 1rem;
-    top: 4.25rem;
-    color: rgba(0, 0, 0, 0.5);
-  }
-
   ::-webkit-scrollbar {
     width: 0.313rem;
   }
@@ -99,11 +94,6 @@
       border-color: $error-color;
     }
   }
-}
-
-.pill-options-container {
-  width: 100%;
-  margin-top: 1rem;
 }
 
 @media (min-width: $breakpoint-mobile) {

--- a/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.spec.tsx
@@ -93,8 +93,8 @@ describe('CreateEvent', () => {
     fireEvent.click(calendarDate);
     let input = utils.getByLabelText('Event Title');
     fireEvent.change(input, { target: { value: 'Clean up at rogers park' } });
-    input = utils.getByLabelText('Description');
-    fireEvent.change(input, { target: { value: 'Cleanup :)' } });
+    input = utils.baseElement.getElementsByClassName('mull-text-area')[0] as HTMLDivElement;
+    fireEvent.input(input, { target: { textContent: 'Cleanup :)' } });
     input = utils.getByLabelText('Location');
     fireEvent.change(input, { target: { value: 'Rogers Park' } });
     const activeRestriction = utils.container.querySelector('.pill-options > .pill-option-active');

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -108,7 +108,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
         ),
       eventTitle: Yup.string()
         .required('Event Title is required.')
-        .max(LIMITS.EVENT_TITLE, `Event Title must be under ${LIMITS.EVENT_TITLE} characters.`)
+        .max(LIMITS.EVENT_TITLE, `Event Title must be at most ${LIMITS.EVENT_TITLE} characters.`)
         .test('EmojiCheck', 'Emojis are not allowed in Event Title.', function (eventTitle) {
           return !hasEmoji(eventTitle);
         }),
@@ -117,7 +117,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
         .required('Event Description is required.')
         .max(
           LIMITS.DESCRIPTION,
-          `Event Description must be under ${LIMITS.DESCRIPTION} characters.`
+          `Event Description must be at most ${LIMITS.DESCRIPTION} characters.`
         ),
       location: Yup.mixed()
         .required('Event Location is required.')

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -274,8 +274,10 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
             <MullTextArea
               title="Description"
               fieldName="description"
-              onChange={(e) => {
-                formik.setFieldValue('description', e.target.textContent);
+              onInput={(e) => {
+                const target = e.target as HTMLDivElement;
+
+                formik.setFieldValue('description', target.textContent);
               }}
               hasErrors={formik.touched.description && !!formik.errors.description}
               errorMessage={formik.errors.description}

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -20,6 +20,7 @@ import {
   CustomFileUpload,
   CustomTextInput,
   MullButton,
+  MullTextArea,
   PillOptions,
   TimeSlider,
 } from './../../components';
@@ -267,28 +268,20 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
               errorMessage={formik.errors.eventTitle}
               svgIcon={<FontAwesomeIcon className="input-icon" icon={faPencilAlt} />}
             />
-            <LocationAutocompleteModal formik={formik} />
-            <div className="textarea-create-event-container">
-              <label className="description-label" htmlFor={'description'}>
-                Description
-              </label>
-              <div className="textarea-sub-container">
-                <textarea
-                  id="description"
-                  className={`description-msg ${
-                    formik.touched.description && !!formik.errors.description ? 'error' : ''
-                  }`}
-                  rows={1}
-                  value={formik.values.description}
-                  onChange={formik.handleChange}
-                />
-              </div>
-              <FontAwesomeIcon className="description-input-icon" icon={faAlignLeft} />
 
-              {formik.touched.description && !!formik.errors.description ? (
-                <span className="error-message">{formik.errors.description}</span>
-              ) : null}
-            </div>
+            <LocationAutocompleteModal formik={formik} />
+
+            <MullTextArea
+              title="Description"
+              fieldName="description"
+              onChange={(e) => {
+                formik.setFieldValue('description', e.target.textContent);
+              }}
+              hasErrors={formik.touched.description && !!formik.errors.description}
+              errorMessage={formik.errors.description}
+              svgIcon={<FontAwesomeIcon className="input-icon" icon={faAlignLeft} />}
+            />
+
             <PillOptions
               options={EventRestrictionMap}
               onChange={handleRestrictions}

--- a/apps/mull-ui/src/app/pages/create-event/location-autocomplete/__snapshots__/location-autocomplete-modal.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/create-event/location-autocomplete/__snapshots__/location-autocomplete-modal.spec.tsx.snap
@@ -10,32 +10,40 @@ exports[`location autocomplete modal should match snapshot 1`] = `
   >
     Location
   </label>
-  <input
-    className="custom-text-input input-border "
-    data-testid="custom-text-input"
-    id="location"
-    name="location"
-    onClick={[Function]}
-    readOnly={true}
-    type="text"
-    value=""
-  />
-  <svg
-    aria-hidden="true"
-    className="svg-inline--fa fa-map-marker-alt fa-w-12 input-icon"
-    data-icon="map-marker-alt"
-    data-prefix="fas"
-    focusable="false"
-    role="img"
-    style={Object {}}
-    viewBox="0 0 384 512"
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className="custom-text-input-sub-container"
   >
-    <path
-      d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
-      fill="currentColor"
-      style={Object {}}
+    <input
+      className="custom-text-input input-border "
+      data-testid="custom-text-input"
+      id="location"
+      name="location"
+      onClick={[Function]}
+      readOnly={true}
+      type="text"
+      value=""
     />
-  </svg>
+    <div
+      className="custom-text-input-icon"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-map-marker-alt fa-w-12 input-icon"
+        data-icon="map-marker-alt"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 384 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </div>
+  </div>
 </div>
 `;

--- a/apps/mull-ui/src/app/pages/login/login.tsx
+++ b/apps/mull-ui/src/app/pages/login/login.tsx
@@ -88,6 +88,7 @@ export const Login = ({ history }: LoginProps) => {
           onChange={formik.handleChange}
           hasErrors={formik.touched.email && !!formik.errors.email}
           errorMessage={formik.errors.email}
+          type="email"
         />
 
         <CustomTextInput
@@ -97,7 +98,7 @@ export const Login = ({ history }: LoginProps) => {
           onChange={formik.handleChange}
           hasErrors={formik.touched.password && !!formik.errors.password}
           errorMessage={formik.errors.password}
-          password
+          type="password"
         />
 
         <button type="submit" className="login">

--- a/apps/mull-ui/src/app/pages/messages/common.ts
+++ b/apps/mull-ui/src/app/pages/messages/common.ts
@@ -1,0 +1,51 @@
+export const updateChatContainerStyle = (
+  setContainerStyle: (value: React.SetStateAction<React.CSSProperties>) => void,
+  targetRef: React.MutableRefObject<HTMLDivElement>
+) => {
+  const chatInputContainer = document.getElementById('chat-input-container');
+  if (chatInputContainer) {
+    const margin =
+      document.documentElement.clientHeight - chatInputContainer.getBoundingClientRect().top;
+    setContainerStyle({ marginBottom: margin + 'px' });
+    setTimeout(() => {
+      window.scrollTo({ top: targetRef.current.clientHeight + 1000 });
+    }, 100);
+  }
+};
+
+export const chatInputOnFocus = (
+  chatInputBot: React.MutableRefObject<string>,
+  setContainerStyle: (value: React.SetStateAction<React.CSSProperties>) => void,
+  targetRef: React.MutableRefObject<HTMLDivElement>
+) => {
+  if (window.innerWidth < 800) {
+    const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
+    botNav.style.display = 'none';
+
+    const chatInputContainer = document.getElementById('chat-input-container');
+
+    chatInputBot.current = chatInputContainer.style.bottom;
+
+    chatInputContainer.style.bottom = '0';
+
+    updateChatContainerStyle(setContainerStyle, targetRef);
+  }
+};
+export const chatInputOnBlur = (
+  chatInputBot: React.MutableRefObject<string>,
+  setContainerStyle: (value: React.SetStateAction<React.CSSProperties>) => void,
+  targetRef: React.MutableRefObject<HTMLDivElement>
+) => {
+  if (window.innerWidth < 800) {
+    const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
+    botNav.style.display = 'block';
+
+    const chatInputContainer = document.getElementsByClassName(
+      'chat-input-container'
+    )[0] as HTMLDivElement;
+
+    chatInputContainer.style.bottom = chatInputBot.current;
+
+    updateChatContainerStyle(setContainerStyle, targetRef);
+  }
+};

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -165,32 +165,36 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
   };
 
   const inputOnFocus = () => {
-    const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
-    botNav.style.display = 'none';
+    if (window.innerWidth < 800) {
+      const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
+      botNav.style.display = 'none';
 
-    const chatInputContainer = document.getElementsByClassName(
-      'chat-input-container'
-    )[0] as HTMLDivElement;
+      const chatInputContainer = document.getElementsByClassName(
+        'chat-input-container'
+      )[0] as HTMLDivElement;
 
-    chatInputBot.current = chatInputContainer.style.bottom;
+      chatInputBot.current = chatInputContainer.style.bottom;
 
-    chatInputContainer.style.bottom = '0';
+      chatInputContainer.style.bottom = '0';
 
-    updateContainerStyle();
-    forceUpdate();
+      updateContainerStyle();
+      forceUpdate();
+    }
   };
   const inputOnBlur = () => {
-    const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
-    botNav.style.display = 'block';
+    if (window.innerWidth < 800) {
+      const botNav = document.getElementsByClassName('bot-nav-container')[0] as HTMLDivElement;
+      botNav.style.display = 'block';
 
-    const chatInputContainer = document.getElementsByClassName(
-      'chat-input-container'
-    )[0] as HTMLDivElement;
+      const chatInputContainer = document.getElementsByClassName(
+        'chat-input-container'
+      )[0] as HTMLDivElement;
 
-    chatInputContainer.style.bottom = chatInputBot.current;
+      chatInputContainer.style.bottom = chatInputBot.current;
 
-    updateContainerStyle();
-    forceUpdate();
+      updateContainerStyle();
+      forceUpdate();
+    }
   };
 
   useEffect(() => {

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -1,4 +1,4 @@
-import { IChatForm, ISerializedPost } from '@mull/types';
+import { IChatForm, ISerializedPost, LIMITS } from '@mull/types';
 import { useFormik } from 'formik';
 import { History } from 'history';
 import React, { ChangeEvent, useContext, useState } from 'react';
@@ -104,7 +104,11 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
         ? Yup.string().optional()
         : Yup.string()
             .required()
-            .test('no-whitespace', "Message can't be empty", (value) => !/^\s*$/.test(value)),
+            .test('no-whitespace', "Message can't be empty", (value) => !/^\s*$/.test(value))
+            .max(
+              LIMITS.POST_MESSAGE,
+              `A post can only have up to ${LIMITS.POST_MESSAGE} characters.`
+            ),
       imageFile: Yup.mixed().test('big-file', 'File size is too large', validateFileSize),
     }),
 
@@ -113,6 +117,13 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
         const uploadedFile = file
           ? (await uploadFile({ variables: { file: file } })).data.uploadFile
           : null;
+
+        // The div which makes up the "textarea" of the chat input isn't tied to the form, and its text needs to be cleared out after submit.
+        const textAreas = document.getElementsByClassName('mull-text-area');
+        for (let i = 0; i < textAreas.length; i++) {
+          const element = textAreas[i];
+          element.textContent = '';
+        }
 
         createPostMutation({
           variables: {

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -105,7 +105,9 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
 
     validationSchema: Yup.object({
       message: file
-        ? Yup.string().optional()
+        ? Yup.string()
+            .optional()
+            .max(LIMITS.POST_MESSAGE, `A post must be at most ${LIMITS.POST_MESSAGE} characters.`)
         : Yup.string()
             .required()
             .test('no-whitespace', "Message can't be empty", (value) => !/^\s*$/.test(value))

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -157,7 +157,8 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       'chat-input-container'
     )[0] as HTMLDivElement;
     if (chatInputContainer) {
-      const margin = window.innerHeight - chatInputContainer.getBoundingClientRect().top;
+      const margin =
+        document.documentElement.clientHeight - chatInputContainer.getBoundingClientRect().top;
       setContainerStyle({ marginBottom: margin + 'px' });
       window.scrollTo({ top: 9999, behavior: 'smooth' });
     }

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -109,10 +109,7 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
         : Yup.string()
             .required()
             .test('no-whitespace', "Message can't be empty", (value) => !/^\s*$/.test(value))
-            .max(
-              LIMITS.POST_MESSAGE,
-              `A post can only have up to ${LIMITS.POST_MESSAGE} characters.`
-            ),
+            .max(LIMITS.POST_MESSAGE, `A post must be at most ${LIMITS.POST_MESSAGE} characters.`),
       imageFile: Yup.mixed().test('big-file', 'File size is too large', validateFileSize),
     }),
 

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -160,7 +160,9 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       const margin =
         document.documentElement.clientHeight - chatInputContainer.getBoundingClientRect().top;
       setContainerStyle({ marginBottom: margin + 'px' });
-      window.scrollTo({ top: 9999, behavior: 'smooth' });
+      setTimeout(() => {
+        window.scrollTo({ top: eventChatRef.current.clientHeight + 1000 });
+      }, 100);
     }
   };
 
@@ -178,7 +180,6 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       chatInputContainer.style.bottom = '0';
 
       updateContainerStyle();
-      forceUpdate();
     }
   };
   const inputOnBlur = () => {
@@ -193,7 +194,6 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       chatInputContainer.style.bottom = chatInputBot.current;
 
       updateContainerStyle();
-      forceUpdate();
     }
   };
 

--- a/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-chat/event-chat.tsx
@@ -1,11 +1,10 @@
 import { IChatForm, ISerializedPost, LIMITS } from '@mull/types';
 import { useFormik } from 'formik';
 import { History } from 'history';
-import React, { ChangeEvent, useContext, useState } from 'react';
-import { Redirect, useParams } from 'react-router-dom';
+import React, { ChangeEvent, CSSProperties, useContext, useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import * as Yup from 'yup';
-import { ROUTES } from '../../../../../src/constants';
 import {
   CreatePostInput,
   Event,
@@ -52,6 +51,8 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       channelName,
     },
   });
+  const [containerStyle, setContainerStyle] = useState<CSSProperties>({ marginBottom: '76px' });
+  const eventChatRef = useRef<HTMLDivElement>(null);
 
   const isEventHost = (event: Event) => {
     if (restrictChatInput) {
@@ -148,6 +149,25 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
       }
     },
   });
+
+  const updateContainerStyle = () => {
+    const chatInputContainer = document.getElementsByClassName(
+      'chat-input-container'
+    )[0] as HTMLDivElement;
+    if (chatInputContainer) {
+      setContainerStyle({ marginBottom: chatInputContainer.clientHeight + 'px' });
+      window.scrollTo({ top: 9999, behavior: 'smooth' });
+    }
+  };
+
+  useEffect(() => {
+    updateContainerStyle();
+  }, []);
+
+  useEffect(() => {
+    updateContainerStyle();
+  }, [formik.values.message]);
+
   if (error) {
     return <Redirect to={ROUTES.LOGIN} />;
   }
@@ -156,7 +176,7 @@ export const EventChat = ({ history, channelName, restrictChatInput }: EventChat
 
   if (data) {
     return (
-      <div className="event-chat">
+      <div className="event-chat" style={containerStyle} ref={eventChatRef}>
         <ChatBubbleList
           posts={data.getChannelByEventId.posts}
           subToMore={subToMore}

--- a/apps/mull-ui/src/app/pages/messages/event-messages/__snapshots__/event-message-list.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/__snapshots__/event-message-list.spec.tsx.snap
@@ -11,16 +11,23 @@ exports[`EventMessageList should match snapshot 1`] = `
       className="custom-text-input-label"
       htmlFor="searchField"
     />
-    <input
-      className="custom-text-input input-border "
-      data-testid="custom-text-input"
-      id="searchField"
-      name="searchField"
-      onChange={[Function]}
-      placeholder="Search"
-      type="text"
-      value=""
-    />
+    <div
+      className="custom-text-input-sub-container"
+    >
+      <input
+        className="custom-text-input input-border "
+        data-testid="custom-text-input"
+        id="searchField"
+        name="searchField"
+        onChange={[Function]}
+        placeholder="Search"
+        type="text"
+        value=""
+      />
+      <div
+        className="custom-text-input-icon"
+      />
+    </div>
   </div>
   <div
     className="event-bullets"

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`EditProfile should match snapshot 1`] = `
         />
         <svg
           aria-hidden="true"
-          className="svg-inline--fa fa-pencil-alt fa-w-16 custom-file-upload-pencil-icon"
+          className="svg-inline--fa fa-pencil-alt fa-w-16 custom-file-upload-pencil-icon button"
           data-icon="pencil-alt"
           data-prefix="fas"
           focusable="false"
@@ -89,15 +89,22 @@ exports[`EditProfile should match snapshot 1`] = `
       >
         Display Name
       </label>
-      <input
-        className="custom-text-input input-border "
-        data-testid="custom-text-input"
-        id="displayName"
-        name="displayName"
-        onChange={[Function]}
-        type="text"
-        value="Jane Doe"
-      />
+      <div
+        className="custom-text-input-sub-container"
+      >
+        <input
+          className="custom-text-input input-border "
+          data-testid="custom-text-input"
+          id="displayName"
+          name="displayName"
+          onChange={[Function]}
+          type="text"
+          value="Jane Doe"
+        />
+        <div
+          className="custom-text-input-icon"
+        />
+      </div>
     </div>
     <label
       className="description-label"

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.tsx
@@ -37,7 +37,7 @@ const EditProfile = ({ history }: EditProfilePageProps) => {
     validationSchema: Yup.object({
       displayName: Yup.string()
         .required('Display name is required')
-        .max(LIMITS.USERNAME, `Display Name must be ${LIMITS.USERNAME} characters or less.`)
+        .max(LIMITS.USERNAME, `Display Name must be at most ${LIMITS.USERNAME} characters.`)
         .test('EmojiCheck', 'Emojis are not allowed in Display Name.', function (displayName) {
           return !hasEmoji(displayName);
         }),

--- a/apps/mull-ui/src/app/pages/register/register.scss
+++ b/apps/mull-ui/src/app/pages/register/register.scss
@@ -25,13 +25,6 @@
   outline: none;
 }
 
-.custom-text-input-container,
-.register {
-  align-self: center;
-  justify-self: center;
-  width: 100%;
-}
-
 .login-here {
   font-size: 0.85rem;
   text-decoration: none;

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -32,7 +32,7 @@ const Register = ({ history }: RegisterProps) => {
     validationSchema: Yup.object({
       name: Yup.string()
         .required('Name is required.')
-        .max(LIMITS.USERNAME, `Name must be ${LIMITS.USERNAME} characters or less.`)
+        .max(LIMITS.USERNAME, `Name must be at most ${LIMITS.USERNAME} characters.`)
         .test('EmojiCheck', 'Emojis are not allowed in Name.', function (name) {
           return !hasEmoji(name);
         }),

--- a/apps/mull-ui/src/app/pages/register/register.tsx
+++ b/apps/mull-ui/src/app/pages/register/register.tsx
@@ -88,6 +88,7 @@ const Register = ({ history }: RegisterProps) => {
           onChange={formik.handleChange}
           hasErrors={formik.touched.email && !!formik.errors.email}
           errorMessage={formik.errors.email}
+          type="email"
         />
         <CustomTextInput
           title="Password"
@@ -96,7 +97,7 @@ const Register = ({ history }: RegisterProps) => {
           onChange={formik.handleChange}
           hasErrors={formik.touched.email && !!formik.errors.password}
           errorMessage={formik.errors.password}
-          password
+          type="password"
         />
         <button type="submit" className="register-button">
           Create Account

--- a/apps/mull-ui/src/app/routes/messages.route.tsx
+++ b/apps/mull-ui/src/app/routes/messages.route.tsx
@@ -36,7 +36,7 @@ const MessagesMainRoute = ({ history }) => {
 const EventMessagesRoutes = ({ match }: RouteChildrenProps) => (
   <PrivateRoute path={`${match.path}/:id`}>
     <EventMessagesHeader>
-      <div className="page-container no-bot-nav">
+      <div className="page-container no-bot-nav with-sub-nav-and-header">
         <PrivateRoute
           exact
           path={`${match.path}/:id/announcements`}

--- a/apps/mull-ui/src/app/routes/messages.route.tsx
+++ b/apps/mull-ui/src/app/routes/messages.route.tsx
@@ -36,7 +36,7 @@ const MessagesMainRoute = ({ history }) => {
 const EventMessagesRoutes = ({ match }: RouteChildrenProps) => (
   <PrivateRoute path={`${match.path}/:id`}>
     <EventMessagesHeader>
-      <div className="page-container with-sub-nav-and-header with-bottom-chat-input">
+      <div className="page-container with-sub-nav-and-header">
         <PrivateRoute
           exact
           path={`${match.path}/:id/announcements`}

--- a/apps/mull-ui/src/app/routes/messages.route.tsx
+++ b/apps/mull-ui/src/app/routes/messages.route.tsx
@@ -36,7 +36,7 @@ const MessagesMainRoute = ({ history }) => {
 const EventMessagesRoutes = ({ match }: RouteChildrenProps) => (
   <PrivateRoute path={`${match.path}/:id`}>
     <EventMessagesHeader>
-      <div className="page-container with-sub-nav-and-header">
+      <div className="page-container no-bot-nav">
         <PrivateRoute
           exact
           path={`${match.path}/:id/announcements`}

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -86,6 +86,28 @@ button,
   border: 1px solid black;
 }
 
+.home-page-no-event {
+  text-align: center;
+}
+
+.input-border {
+  border-radius: 20px;
+  border: 1.5px $primary-color solid;
+  &.error {
+    border-color: #ff0000;
+  }
+}
+
+.input-icon {
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.error {
+  .input-icon {
+    color: red;
+  }
+}
+
 @media (min-width: $breakpoint-mobile) {
   .nav-button,
   .nav-middle-button {

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -91,7 +91,7 @@ button,
 }
 
 .input-border {
-  border-radius: 20px;
+  border-radius: 15px;
   border: 1.5px $primary-color solid;
   &.error {
     border-color: #ff0000;

--- a/apps/mull-ui/src/variables.scss
+++ b/apps/mull-ui/src/variables.scss
@@ -1,6 +1,6 @@
 // sass mq variable
 
-$breakpoint-mobile: 50em;
+$breakpoint-mobile: 50rem;
 
 // Colors
 $background-color: #ffffff;

--- a/libs/types/src/forms.ts
+++ b/libs/types/src/forms.ts
@@ -38,4 +38,5 @@ export const LIMITS = {
   USERNAME: 64,
   EVENT_TITLE: 64,
   IMAGE_SIZE: 10000000,
+  POST_MESSAGE: 512,
 };


### PR DESCRIPTION
closes #315

To test this PR, make sure the following points are addressed:
- 87.1 Remove chatbox autofill
    - I didn't get to test this one, but looking online I just needed to set autoComplete to off on the form
- 87.2 Don’t allow empty spaces without photos to be sent 
- 87.3 Add username to chat bubbles
- 87.4 Text input area should grow to a certain size if the message is really long (keeping in mind the backend varchar length)
    - I've gone through several attempts to do this, I thought there would be a native solution to this, but I guess not ¯\\\_(ツ)\_/¯. The "textarea" is actually a div, so unfortunately you can't treat it as a normal form element :/. This isn't a big issue, just something to keep in mind
- 87.5 Text message limit should be shown (or figure out a way to send long messages)
    - You'll see this as a `xx/512` once you approach the limit. you'll see a negative number once you go over the limit.
- 87.6 Profile pics are clickable and should redirect to their respective profile page
- 87.7 Remove bottom nav when keyboard is showing (mobile)
    - My implementation doesn't take into account users who resize their window to try and break this, so don't @ me about that.