### PR TITLE
TASK-90: EventCard Styling/UX Cleanup

### DIFF
--- a/apps/mull-api/src/app/event/event.mockdata.ts
+++ b/apps/mull-api/src/app/event/event.mockdata.ts
@@ -108,6 +108,29 @@ export const mockAllEvents: Event[] = [
       post: null,
     },
   },
+  {
+    id: 39,
+    title: 'participants',
+    description: 'Vroom Vroom',
+    startDate: new Date('2020-10-27T01:31:00.000Z'),
+    endDate: new Date('2020-11-01T01:31:00.000Z'),
+    restriction: 0,
+    host: userWithId1,
+    coHosts: [userWithId7],
+    participants: mockAllUsers,
+    location: {
+      id: 1,
+      title: 'locationA',
+      coordinates: null,
+      placeId: 'googlePlaceIdA',
+      event: null,
+    },
+    image: {
+      id: 1,
+      mediaType: 'jpeg',
+      post: null,
+    },
+  },
 ];
 
 export const mockQueryReturn = [
@@ -148,4 +171,16 @@ export const mockImage: Media = {
   id: 1,
   mediaType: 'jpeg',
   post: null,
+};
+
+export const mockGetOneEventWithParticipants: Event = {
+  id: 39,
+  title: 'participants',
+  description: 'Vroom Vroom',
+  startDate: new Date('2020-10-27T01:31:00.000Z'),
+  endDate: new Date('2020-11-01T01:31:00.000Z'),
+  restriction: 0,
+  host: userWithId1,
+  coHosts: [userWithId7],
+  participants: [userWithId1, userWithId7, userWithId3],
 };

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -1,7 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { User } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
-import { mockAllEvents, mockImage, mockPartialEvent, mockGetOneEventWithParticipants } from './event.mockdata';
+import {
+  mockAllEvents,
+  mockImage,
+  mockPartialEvent,
+  mockGetOneEventWithParticipants,
+} from './event.mockdata';
 import { EventResolver } from './event.resolver';
 import { DEFAULT_EVENT_CHANNELS, EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';

--- a/apps/mull-api/src/app/event/event.resolver.spec.ts
+++ b/apps/mull-api/src/app/event/event.resolver.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { User } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
-import { mockAllEvents, mockImage, mockPartialEvent } from './event.mockdata';
+import { mockAllEvents, mockImage, mockPartialEvent, mockGetOneEventWithParticipants } from './event.mockdata';
 import { EventResolver } from './event.resolver';
 import { DEFAULT_EVENT_CHANNELS, EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
@@ -45,6 +45,9 @@ const mockEventService = () => ({
     const currentDateTime = new Date();
     return mockAllEvents.find((event) => event.host.id === id && event.endDate < currentDateTime);
   }),
+  getThreeRandomParticipants: jest
+    .fn()
+    .mockReturnValue(mockGetOneEventWithParticipants.participants),
 });
 
 describe('UserResolver', () => {
@@ -146,5 +149,10 @@ describe('UserResolver', () => {
   it(`should get a user's portfolio`, async () => {
     const userPortfolio = await resolver.portfolioEvents(mockAllEvents[0].host.id);
     expect(userPortfolio).toEqual(mockAllEvents[0]);
+  });
+
+  it(`should get at most three participants`, async () => {
+    const participants = await resolver.threeParticipant(mockAllEvents[0].id);
+    expect(participants.length).toBeLessThanOrEqual(3);
   });
 });

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -55,7 +55,9 @@ export class EventResolver {
   }
 
   @Query(/* istanbul ignore next */ () => [User])
-  async threeParticipant(@Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number) {
+  async threeParticipant(
+    @Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number
+  ) {
     return this.eventService.getThreeRandomParticipants(eventId);
   }
 

--- a/apps/mull-api/src/app/event/event.resolver.ts
+++ b/apps/mull-api/src/app/event/event.resolver.ts
@@ -1,7 +1,7 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthenticatedUser, AuthGuard } from '../auth/auth.guard';
-import { Event, Media } from '../entities';
+import { Event, Media, User } from '../entities';
 import { EventService } from './event.service';
 import { CreateEventInput, UpdateEventInput } from './inputs/event.input';
 
@@ -52,6 +52,11 @@ export class EventResolver {
   @Query(/* istanbul ignore next */ () => [Event])
   async discoverEvents(@AuthenticatedUser() userId: number) {
     return this.eventService.getEventsRecommendedToUser(userId);
+  }
+
+  @Query(/* istanbul ignore next */ () => [User])
+  async threeParticipant(@Args('eventId', { type: /* istanbul ignore next */ () => Int }) eventId: number) {
+    return this.eventService.getThreeRandomParticipants(eventId);
   }
 
   @Mutation(/* istanbul ignore next */ () => Event)

--- a/apps/mull-api/src/app/event/event.service.spec.ts
+++ b/apps/mull-api/src/app/event/event.service.spec.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { Event } from '../entities';
 import { mockAllUsers } from '../user/user.mockdata';
 import { MockType } from '../user/user.service.spec';
-import { mockAllEvents, mockPartialEvent } from './event.mockdata';
+import { mockAllEvents, mockPartialEvent, mockGetOneEventWithParticipants } from './event.mockdata';
 import { DEFAULT_EVENT_CHANNELS, EventService } from './event.service';
 import { CreateEventInput } from './inputs/event.input';
 
@@ -29,6 +29,8 @@ const mockEventRepository = () => ({
     setParameters: jest.fn().mockReturnThis(),
     getQuery: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockReturnValue(mockAllEvents[0]),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
   })),
   query: jest.fn().mockReturnThis(),
 });
@@ -207,5 +209,17 @@ describe('EventService', () => {
   it(`should return a user's portfolio`, async () => {
     const portfolio = await service.getUserEventsPortfolio(mockAllEvents[0].host.id);
     expect(portfolio).toEqual(mockAllEvents[0]);
+  });
+
+  it(`should get some participants from an event`, async () => {
+    repository.createQueryBuilder.mockImplementation(() => ({
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockReturnValue(mockGetOneEventWithParticipants),
+    }));
+    const participants = await service.getThreeRandomParticipants(mockAllEvents[4].id);
+    expect(participants).toEqual(mockGetOneEventWithParticipants.participants);
   });
 });

--- a/apps/mull-api/src/app/event/event.service.ts
+++ b/apps/mull-api/src/app/event/event.service.ts
@@ -187,4 +187,22 @@ export class EventService {
       .setParameters({ userId })
       .getMany();
   }
+
+  /**
+   * Randomly selects three participants from a givin event
+   * @param eventId
+   * @returns
+   */
+  async getThreeRandomParticipants(eventId: number): Promise<User[]> {
+    const { participants } = await this.eventRepository
+      .createQueryBuilder('event')
+      .leftJoinAndSelect('event.participants', 'participant')
+      .leftJoinAndSelect('participant.avatar', 'avatar')
+      .where('event.id = :eventId', { eventId })
+      .orderBy('RAND()')
+      .limit(3)
+      .getOne();
+
+    return participants;
+  }
 }

--- a/apps/mull-api/src/schema.gql
+++ b/apps/mull-api/src/schema.gql
@@ -196,6 +196,7 @@ type Query {
   portfolioCount(id: Int!): Int!
   portfolioEvents(id: Int!): [Event!]!
   posts: [Post!]!
+  threeParticipant(eventId: Int!): [User!]!
   user(id: Int!): User!
   userPortfolioEvents: [Event!]!
   users: [User!]!

--- a/apps/mull-ui/src/app/components/event-card/__snapshots__/event-card.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/event-card/__snapshots__/event-card.spec.tsx.snap
@@ -40,25 +40,6 @@ exports[`EventCard should match snapshot 1`] = `
         15km • 1260 Remembrance Road Montreal, Qc
       </div>
     </div>
-    <div
-      className="event-members-div"
-    >
-      <img
-        alt="participant_1"
-        className="profile-picture"
-        src="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-      />
-      <img
-        alt="participant_2"
-        className="profile-picture"
-        src="https://i.pinimg.com/236x/92/f0/ed/92f0edd9b0ecefdd5b7a48b8e1f7d340.jpg"
-      />
-      <img
-        alt="participant_3"
-        className="profile-picture"
-        src="https://pbs.twimg.com/profile_images/748593045566853124/9DDVz0uT_400x400.jpg"
-      />
-    </div>
   </div>
 </div>
 `;

--- a/apps/mull-ui/src/app/components/event-card/event-card.scss
+++ b/apps/mull-ui/src/app/components/event-card/event-card.scss
@@ -25,7 +25,7 @@
   padding: 0.4rem;
   text-align: center;
 
-  border: 1px solid rgba(0, 0, 0, 0.55);
+  box-shadow: 0.1rem 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
 
   div {
     font-size: 0.75rem;

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ISerializedEvent } from '@mull/types';
 import React, { useState } from 'react';
 import { useJoinEventMutation, useLeaveEventMutation } from '../../../generated/graphql';
-import { dummyProfilePictures } from '../../../mockdata'; // TODO query the participants profile pictures
 import { formatDate, getMediaUrl } from '../../../utilities';
 import EventMembers from '../event-members/event-members';
 import './event-card.scss';
@@ -37,7 +36,7 @@ export const EventCard = ({
   const isEventExpired = currentDate.getTime() > new Date(event.endDate).getTime();
   return (
     <div className="event-card-container button" onClick={onClick} style={style}>
-      <img className="event-card-image" src={getMediaUrl(event.id)} alt="Event" />
+      <img className="event-card-image" src={getMediaUrl(event.image.id)} alt="Event" />
       <div className="event-card-datetime" data-testid="event-card-datetime">
         <div className="date-style">{`${day} ${month.toUpperCase()}`}</div>
         <div>{time.replace(/\s/g, '')}</div>
@@ -70,7 +69,7 @@ export const EventCard = ({
 
           <div className="event-card-location">{`${distance}km • ${event.location.title}`}</div>
         </div>
-        <EventMembers profilePictures={dummyProfilePictures} />
+        <EventMembers eventId={event.id} />
         {/* TODO: Implement share */}
         {/* <button
           className="event-card-share"

--- a/apps/mull-ui/src/app/components/event-members/__snapshots__/event-members.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/event-members/__snapshots__/event-members.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventMembers should render successfully 1`] = `null`;

--- a/apps/mull-ui/src/app/components/event-members/event-members.spec.tsx
+++ b/apps/mull-ui/src/app/components/event-members/event-members.spec.tsx
@@ -1,11 +1,37 @@
-import { render } from '@testing-library/react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { ISerializedEvent } from '@mull/types';
+import { GetThreeRandomParticipantsDocument } from '../../../generated/graphql';
 import React from 'react';
-import { dummyProfilePictures } from '../../../mockdata';
-import EventMembers from './event-members';
+import renderer, { act as actRenderer } from 'react-test-renderer';
+import { EventMembers } from '..';
+import { dummyEvent } from '../../../mockdata';
 
 describe('EventMembers', () => {
-  it('should render successfully', () => {
-    const { baseElement } = render(<EventMembers profilePictures={dummyProfilePictures} />);
-    expect(baseElement).toBeTruthy();
+  const renderHelper = (mocks: MockedResponse[], event: ISerializedEvent) => {
+    return (
+      <MockedProvider mocks={mocks}>
+        <EventMembers eventId={event.id} />
+      </MockedProvider>
+    );
+  };
+
+  it('should render successfully', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: GetThreeRandomParticipantsDocument,
+          variables: { eventId: dummyEvent.id },
+        },
+        result: {
+          data: { participants: dummyEvent.participants },
+        },
+      },
+    ];
+
+    await actRenderer(async () => {
+      const tree = renderer.create(renderHelper(mocks, dummyEvent));
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(tree.toJSON()).toMatchSnapshot();
+    });
   });
 });

--- a/apps/mull-ui/src/app/components/event-members/event-members.tsx
+++ b/apps/mull-ui/src/app/components/event-members/event-members.tsx
@@ -1,17 +1,30 @@
+import { useGetThreeRandomParticipantsQuery, User } from 'apps/mull-ui/src/generated/graphql';
 import React from 'react';
+import { avatarUrl } from '../../../utilities';
 import './event-members.scss';
 
 export interface EventMembersProps {
-  profilePictures: string[];
+  eventId: number;
 }
 
-export const EventMembers = ({ profilePictures }: EventMembersProps) => {
-  const profileImages = profilePictures
-    .slice(0, 3)
-    .map((image, index) => (
-      <img className="profile-picture" key={index} src={image} alt={`participant_${index + 1}`} />
+export const EventMembers = ({ eventId }: EventMembersProps) => {
+  const { data: participantsData } = useGetThreeRandomParticipantsQuery({
+    variables: {
+      eventId: eventId,
+    },
+  });
+  if (participantsData) {
+    const profileImages = participantsData.threeParticipant.map((participant, index) => (
+      <img
+        className="profile-picture"
+        key={index}
+        src={avatarUrl(participant as User)}
+        alt={`participant_${index + 1}`}
+      />
     ));
-  return <div className="event-members-div">{profileImages}</div>;
+    return <div className="event-members-div">{profileImages}</div>;
+  }
+  return null;
 };
 
 export default EventMembers;

--- a/apps/mull-ui/src/app/components/event-members/event-members.tsx
+++ b/apps/mull-ui/src/app/components/event-members/event-members.tsx
@@ -1,4 +1,4 @@
-import { useGetThreeRandomParticipantsQuery, User } from 'apps/mull-ui/src/generated/graphql';
+import { useGetThreeRandomParticipantsQuery, User } from '../../../generated/graphql';
 import React from 'react';
 import { avatarUrl } from '../../../utilities';
 import './event-members.scss';

--- a/apps/mull-ui/src/app/components/pill-options/__snapshots__/pill-options.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/pill-options/__snapshots__/pill-options.spec.tsx.snap
@@ -2,31 +2,40 @@
 
 exports[`PillOptions should match snapshot 1`] = `
 <div
-  className="pill-options"
+  className="pill-options-container"
 >
-  <button
-    className="pill-option pill-option-active"
-    data-testid="pill-id-0"
-    onClick={[Function]}
-    type="button"
+  <label
+    className="custom-text-input-label"
   >
-    Yes
-  </button>
-  <button
-    className="pill-option pill-option-inactive"
-    data-testid="pill-id-1"
-    onClick={[Function]}
-    type="button"
+    Restriction
+  </label>
+  <div
+    className="pill-options"
   >
-    No
-  </button>
-  <button
-    className="pill-option pill-option-inactive"
-    data-testid="pill-id-2"
-    onClick={[Function]}
-    type="button"
-  >
-    Maybe
-  </button>
+    <button
+      className="pill-option pill-option-active"
+      data-testid="pill-id-0"
+      onClick={[Function]}
+      type="button"
+    >
+      Yes
+    </button>
+    <button
+      className="pill-option pill-option-inactive"
+      data-testid="pill-id-1"
+      onClick={[Function]}
+      type="button"
+    >
+      No
+    </button>
+    <button
+      className="pill-option pill-option-inactive"
+      data-testid="pill-id-2"
+      onClick={[Function]}
+      type="button"
+    >
+      Maybe
+    </button>
+  </div>
 </div>
 `;

--- a/apps/mull-ui/src/app/pages/profile/other-user-profile/__snapshots__/other-user-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/other-user-profile/__snapshots__/other-user-profile.spec.tsx.snap
@@ -113,7 +113,7 @@ exports[`OtherUserProfile should match snapshot 1`] = `
       <img
         alt="Event"
         className="event-card-image"
-        src="http://localhost:3333/api/media/9"
+        src="http://localhost:3333/api/media/10"
       />
       <div
         className="event-card-datetime"
@@ -144,25 +144,6 @@ exports[`OtherUserProfile should match snapshot 1`] = `
           >
             15km • 51067 Schimmel Cliff, North Christop, Connecticut, 75399-7391
           </div>
-        </div>
-        <div
-          className="event-members-div"
-        >
-          <img
-            alt="participant_1"
-            className="profile-picture"
-            src="https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg"
-          />
-          <img
-            alt="participant_2"
-            className="profile-picture"
-            src="https://i.pinimg.com/236x/92/f0/ed/92f0edd9b0ecefdd5b7a48b8e1f7d340.jpg"
-          />
-          <img
-            alt="participant_3"
-            className="profile-picture"
-            src="https://pbs.twimg.com/profile_images/748593045566853124/9DDVz0uT_400x400.jpg"
-          />
         </div>
       </div>
     </div>

--- a/apps/mull-ui/src/generated/graphql.tsx
+++ b/apps/mull-ui/src/generated/graphql.tsx
@@ -316,6 +316,7 @@ export type Query = {
   portfolioCount: Scalars['Int'];
   portfolioEvents: Array<Event>;
   posts: Array<Post>;
+  threeParticipant: Array<User>;
   user: User;
   userPortfolioEvents: Array<Event>;
   users: Array<User>;
@@ -380,6 +381,11 @@ export type QueryPortfolioCountArgs = {
 
 export type QueryPortfolioEventsArgs = {
   id: Scalars['Int'];
+};
+
+
+export type QueryThreeParticipantArgs = {
+  eventId: Scalars['Int'];
 };
 
 
@@ -917,6 +923,22 @@ export type GetTrueFriendsQuery = (
     & { avatar?: Maybe<(
       { __typename?: 'Media' }
       & Pick<Media, 'mediaType' | 'id'>
+    )> }
+  )> }
+);
+
+export type GetThreeRandomParticipantsQueryVariables = Exact<{
+  eventId: Scalars['Int'];
+}>;
+
+
+export type GetThreeRandomParticipantsQuery = (
+  { __typename?: 'Query' }
+  & { threeParticipant: Array<(
+    { __typename?: 'User' }
+    & { avatar?: Maybe<(
+      { __typename?: 'Media' }
+      & Pick<Media, 'id'>
     )> }
   )> }
 );
@@ -1987,6 +2009,41 @@ export function useGetTrueFriendsLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type GetTrueFriendsQueryHookResult = ReturnType<typeof useGetTrueFriendsQuery>;
 export type GetTrueFriendsLazyQueryHookResult = ReturnType<typeof useGetTrueFriendsLazyQuery>;
 export type GetTrueFriendsQueryResult = Apollo.QueryResult<GetTrueFriendsQuery, GetTrueFriendsQueryVariables>;
+export const GetThreeRandomParticipantsDocument = gql`
+    query GetThreeRandomParticipants($eventId: Int!) {
+  threeParticipant(eventId: $eventId) {
+    avatar {
+      id
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetThreeRandomParticipantsQuery__
+ *
+ * To run a query within a React component, call `useGetThreeRandomParticipantsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetThreeRandomParticipantsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetThreeRandomParticipantsQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useGetThreeRandomParticipantsQuery(baseOptions: Apollo.QueryHookOptions<GetThreeRandomParticipantsQuery, GetThreeRandomParticipantsQueryVariables>) {
+        return Apollo.useQuery<GetThreeRandomParticipantsQuery, GetThreeRandomParticipantsQueryVariables>(GetThreeRandomParticipantsDocument, baseOptions);
+      }
+export function useGetThreeRandomParticipantsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetThreeRandomParticipantsQuery, GetThreeRandomParticipantsQueryVariables>) {
+          return Apollo.useLazyQuery<GetThreeRandomParticipantsQuery, GetThreeRandomParticipantsQueryVariables>(GetThreeRandomParticipantsDocument, baseOptions);
+        }
+export type GetThreeRandomParticipantsQueryHookResult = ReturnType<typeof useGetThreeRandomParticipantsQuery>;
+export type GetThreeRandomParticipantsLazyQueryHookResult = ReturnType<typeof useGetThreeRandomParticipantsLazyQuery>;
+export type GetThreeRandomParticipantsQueryResult = Apollo.QueryResult<GetThreeRandomParticipantsQuery, GetThreeRandomParticipantsQueryVariables>;
 export const PostAddedDocument = gql`
     subscription PostAdded($channelId: Int!) {
   postAdded(channelId: $channelId) {

--- a/apps/mull-ui/src/graphql/queries.gql
+++ b/apps/mull-ui/src/graphql/queries.gql
@@ -271,3 +271,11 @@ query GetTrueFriends {
     }
   }
 }
+
+query GetThreeRandomParticipants($eventId: Int!) {
+  threeParticipant(eventId: $eventId) {
+    avatar {
+      id
+    }
+  }
+}

--- a/apps/mull-ui/src/mockdata.ts
+++ b/apps/mull-ui/src/mockdata.ts
@@ -1,12 +1,5 @@
 import { DetectionResult, EventRestriction, ISerializedEvent, ISerializedPost } from '@mull/types';
 
-// TODO delete when US 2.1 is completed
-export const dummyProfilePictures: string[] = [
-  'https://blog.photofeeler.com/wp-content/uploads/2017/04/are-bumble-profiles-fake-how-many.jpeg',
-  'https://i.pinimg.com/236x/92/f0/ed/92f0edd9b0ecefdd5b7a48b8e1f7d340.jpg',
-  'https://pbs.twimg.com/profile_images/748593045566853124/9DDVz0uT_400x400.jpg',
-];
-
 export const dummyEvent: ISerializedEvent = {
   id: 1,
   title: 'Test title',
@@ -23,6 +16,10 @@ export const dummyEvent: ISerializedEvent = {
     {
       id: 1,
       name: 'User 1',
+      avatar: {
+        id: 1,
+        mediaType: 'jpeg',
+      },
     },
     {
       id: 2,

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -76,6 +76,7 @@ export interface IPoint {
 export interface IUser {
   id: number;
   name?: string;
+  avatar?: IMedia;
 }
 
 export interface IMedia {


### PR DESCRIPTION
closes #318 

Add Box Shadow to Time Event and Query Participants Avatar

No participants:
![Screenshot 2021-04-07 140305](https://user-images.githubusercontent.com/44760251/113915137-67687480-97ac-11eb-84ab-6b162a5fbf29.png)

One Participant:
![Screenshot 2021-04-07 140320](https://user-images.githubusercontent.com/44760251/113915196-77805400-97ac-11eb-9af9-e253fdffad06.png)

Two participants:
![Screenshot 2021-04-07 140338](https://user-images.githubusercontent.com/44760251/113915220-7e0ecb80-97ac-11eb-909e-8b42ec5052c1.png)

Three or more participants:
![Screenshot 2021-04-07 140354](https://user-images.githubusercontent.com/44760251/113915247-89fa8d80-97ac-11eb-9029-317237fba4a7.png)

Will randomly query three participants so the avatars will be different all the time.

Oh and removed the border and added box shadow
![image](https://user-images.githubusercontent.com/44760251/113915750-24f36780-97ad-11eb-9f09-c6aad743f267.png)


