### PR TITLE
FIX: Create global styling for empty array messages

### DIFF
--- a/apps/mull-ui/src/app/pages/direct-message/direct-message.scss
+++ b/apps/mull-ui/src/app/pages/direct-message/direct-message.scss
@@ -2,6 +2,5 @@
   margin-top: 2rem;
   .search-results {
     padding-top: 2rem;
-    text-align: center;
   }
 }

--- a/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
+++ b/apps/mull-ui/src/app/pages/direct-message/direct-message.tsx
@@ -43,7 +43,7 @@ const DirectMessagePage = ({ history }: DirectMessagePageProps) => {
       {contactRows.length > 0 ? (
         <div>{contactRows}</div>
       ) : (
-        <p className="search-results">No results found</p>
+        <p className="search-results empty-array-msg">No results found</p>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
+++ b/apps/mull-ui/src/app/pages/home/discover/discover-page.tsx
@@ -25,7 +25,7 @@ export const DiscoverPage = ({ history }) => {
       {eventCards && eventCards.length > 0 ? (
         eventCards
       ) : (
-        <div className="home-page-no-event">No events found</div>
+        <div className="empty-array-msg">No events found</div>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
+++ b/apps/mull-ui/src/app/pages/home/my-events/my-events.tsx
@@ -29,7 +29,7 @@ export const MyEventsPage = ({ history }) => {
       {eventCards && eventCards.length > 0 ? (
         eventCards
       ) : (
-        <div className="home-page-no-event">No events found</div>
+        <div className="empty-array-msg">No events found</div>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
+++ b/apps/mull-ui/src/app/pages/home/upcoming/upcoming.tsx
@@ -25,7 +25,7 @@ export const UpcomingPage = ({ history }) => {
       {eventCards && eventCards.length > 0 ? (
         eventCards
       ) : (
-        <div className="home-page-no-event">No events found</div>
+        <div className="empty-array-msg">No events found</div>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.scss
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.scss
@@ -7,6 +7,5 @@
   }
   .event-messages-not-found {
     padding-top: 2rem;
-    text-align: center;
   }
 }

--- a/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/event-message-list.tsx
@@ -43,7 +43,7 @@ export const EventMessageList = ({ history }) => {
       {eventBullets.length ? (
         <div className="event-bullets">{eventBullets}</div>
       ) : (
-        <p className="event-messages-not-found">No results found</p>
+        <p className="event-messages-not-found empty-array-msg">No results found</p>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
+++ b/apps/mull-ui/src/app/pages/profile/add-friends/add-friends.tsx
@@ -104,7 +104,9 @@ export const AddFriendsPage = ({ history }: AddFriendsPageProps) => {
                   />
                 ))
               ) : (
-                <div className="add-friends-no-request">No friend requests from others</div>
+                <div className="add-friends-no-request empty-array-msg text-left">
+                  No friend requests from others
+                </div>
               )}
             </div>
             <div className="add-friends-section">
@@ -129,7 +131,9 @@ export const AddFriendsPage = ({ history }: AddFriendsPageProps) => {
                   />
                 ))
               ) : (
-                <div className="add-friends-no-request">No pending friend requests</div>
+                <div className="add-friends-no-request empty-array-msg text-left">
+                  No pending friend requests
+                </div>
               )}
             </div>
           </>

--- a/apps/mull-ui/src/app/pages/profile/myFriends-profile/myFriends-profile.scss
+++ b/apps/mull-ui/src/app/pages/profile/myFriends-profile/myFriends-profile.scss
@@ -13,9 +13,6 @@
   .contact-container {
     margin-top: 0.625rem;
   }
-  .no-friends-msg {
-    text-align: center;
-  }
 }
 
 @media (min-width: $breakpoint-mobile) {

--- a/apps/mull-ui/src/app/pages/profile/myFriends-profile/myFriends-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/myFriends-profile/myFriends-profile.tsx
@@ -89,7 +89,7 @@ const MyFriends = ({ history }) => {
       {finalFriendsList.length > 0 ? (
         finalFriendsList
       ) : (
-        <p className="no-friends-msg">No friends found </p>
+        <p className="empty-array-msg">No friends found </p>
       )}
     </div>
   );

--- a/apps/mull-ui/src/app/pages/profile/other-user-profile/other-user-profile.scss
+++ b/apps/mull-ui/src/app/pages/profile/other-user-profile/other-user-profile.scss
@@ -7,7 +7,3 @@
     }
   }
 }
-
-.no-events-found-msg {
-  text-align: center;
-}

--- a/apps/mull-ui/src/app/pages/profile/other-user-profile/other-user-profile.tsx
+++ b/apps/mull-ui/src/app/pages/profile/other-user-profile/other-user-profile.tsx
@@ -67,7 +67,7 @@ export const OtherUserProfilePage = ({
         {eventCards.length > 0 ? (
           eventCards
         ) : (
-          <div className="no-events-found-msg">No portfolio found</div>
+          <div className="empty-array-msg">No portfolio found</div>
         )}
       </div>
     </div>

--- a/apps/mull-ui/src/app/pages/profile/user-portfolio/user-portfolio.tsx
+++ b/apps/mull-ui/src/app/pages/profile/user-portfolio/user-portfolio.tsx
@@ -24,7 +24,11 @@ export const UserPortfolio = ({ history }) => {
       <MullBackButton>Profile</MullBackButton>
       <div className="user-portfolio-container">
         <h1 className="user-portfolio-title">My Portfolio</h1>
-        {eventCards && eventCards.length > 0 ? eventCards : <div>No completed events</div>}
+        {eventCards && eventCards.length > 0 ? (
+          eventCards
+        ) : (
+          <div className="empty-array-msg">No completed events</div>
+        )}
       </div>
     </div>
   );

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -86,14 +86,18 @@ button,
   border: 1px solid black;
 }
 
-.home-page-no-event {
-  text-align: center;
-}
-
 @media (min-width: $breakpoint-mobile) {
   .nav-button,
   .nav-middle-button {
     width: $desktop-nav-button-size;
     height: $desktop-nav-button-size;
+  }
+}
+
+.empty-array-msg {
+  text-align: center;
+  color: #777;
+  &.text-left {
+    text-align: left;
   }
 }


### PR DESCRIPTION
This creates common styling for all empty array messages.

If an original div class had more than `text-align: center` as its styling, then that className was kept and `empty-array-msg` was added on top after removing repetitions. Otherwise, that className was deleted and was replaced with `empty-array-msg`

Before:
![image](https://user-images.githubusercontent.com/33991121/113960666-cc46bd80-97f2-11eb-949f-60e9905503eb.png)


After:
![image](https://user-images.githubusercontent.com/33991121/113960633-c18c2880-97f2-11eb-84ae-969a7a8e23ad.png)
