### PR TITLE
Task 40: Production Optimization

### DIFF
--- a/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
+++ b/apps/mull-ui-e2e/src/integration/US-2.8.spec.ts
@@ -10,7 +10,7 @@ frameSizes.forEach((frame) => {
 
     it('should join an event on the discover event page', () => {
       cy.visit('http://localhost:4200/home/discover');
-      cy.get('#event-card-join').first().click();
+      cy.get('.event-card-join').first().click();
     });
 
     it('should join an event on the preview event page', () => {
@@ -21,7 +21,7 @@ frameSizes.forEach((frame) => {
 
     it('should leave an event on the upcoming event page', () => {
       cy.visit('http://localhost:4200/home/upcoming');
-      cy.get('#event-card-join').first().click();
+      cy.get('.event-card-join').first().click();
     });
 
     it('should leave an event on the preview event page', () => {

--- a/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
+++ b/apps/mull-ui/src/app/components/chat-bubble/chat-bubble.scss
@@ -48,7 +48,7 @@
 .chat-bubble-header {
   display: flex;
   position: relative;
-  color: $inactive-button-color;
+  color: $inactive-text-color;
   justify-content: center;
 
   * {

--- a/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
@@ -74,6 +74,7 @@ exports[`ChatInput should match snapshot 1`] = `
           className="mull-text-area-icon"
         >
           <button
+            aria-label="Send message"
             className="chat-input-button"
             onClick={[Function]}
             type="button"

--- a/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/chat-input/__snapshots__/chat-input.spec.tsx.snap
@@ -62,6 +62,7 @@ exports[`ChatInput should match snapshot 1`] = `
         className="mull-text-area-sub-container grow-wrap"
       >
         <div
+          aria-label="chat-input-textarea"
           className="mull-text-area input-border "
           contentEditable={true}
           data-testid="mull-text-area"

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -74,6 +74,11 @@
 }
 
 @media (min-width: $breakpoint-mobile) {
+  .chat-input-form {
+    .custom-text-input {
+      margin-top: 0;
+    }
+  }
   .chat-input-container {
     width: $page-container-width;
     margin-left: auto;

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.scss
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.scss
@@ -26,7 +26,7 @@
     width: 2rem;
     height: 2rem;
     border-radius: 100%;
-    background: $primary-color;
+    background: $primary-color-lightened;
     box-sizing: border-box;
     padding: 0.3em;
     svg {
@@ -34,7 +34,7 @@
     }
   }
   svg {
-    color: $primary-color;
+    color: $primary-color-lightened;
     &.custom-file-upload-icon {
       font-size: 1.5em; //em used to follow fontawesome standards for sizing
       padding: 0.2rem;

--- a/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
+++ b/apps/mull-ui/src/app/components/chat-input/chat-input.tsx
@@ -100,7 +100,12 @@ export const ChatInput = ({
           hasErrors={null}
           errorMessage={null}
           svgIcon={
-            <button type="button" className="chat-input-button" onClick={onSubmit}>
+            <button
+              aria-label="Send message"
+              type="button"
+              className="chat-input-button"
+              onClick={onSubmit}
+            >
               <FontAwesomeIcon icon={faPaperPlane} />
             </button>
           }

--- a/apps/mull-ui/src/app/components/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/custom-text-input/__snapshots__/custom-text-input.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`CustomTextInput should match snapshot 1`] = `
     className="custom-text-input-sub-container"
   >
     <input
+      aria-label="text"
       className="custom-text-input input-border error"
       data-testid="custom-text-input"
       id="text"

--- a/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
+++ b/apps/mull-ui/src/app/components/custom-text-input/custom-text-input.tsx
@@ -54,6 +54,7 @@ export const CustomTextInput = ({
       <div className="custom-text-input-sub-container">
         <input
           className={`custom-text-input input-border ${hasErrors ? 'error' : ''}`}
+          aria-label={fieldName}
           id={fieldName}
           name={fieldName}
           data-testid="custom-text-input"

--- a/apps/mull-ui/src/app/components/event-card/event-card.tsx
+++ b/apps/mull-ui/src/app/components/event-card/event-card.tsx
@@ -53,7 +53,6 @@ export const EventCard = ({
             }
           }}
           className={`event-card-join ${joined ? 'joined' : 'not-joined'}`}
-          id={'event-card-join'}
         >
           {joined ? (
             <FontAwesomeIcon icon={faCheck} />

--- a/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
+++ b/apps/mull-ui/src/app/components/mull-text-area/mull-text-area.tsx
@@ -40,6 +40,7 @@ export function MullTextArea({
       </label>
       <div className="mull-text-area-sub-container grow-wrap" ref={grower}>
         <div
+          aria-label={fieldName}
           ref={inputRef}
           className={`mull-text-area input-border ${hasErrors ? 'error' : ''}`}
           id={fieldName}

--- a/apps/mull-ui/src/app/components/navigation/bot-nav-bar/__snapshots__/bot-nav-bar.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/navigation/bot-nav-bar/__snapshots__/bot-nav-bar.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`BotNavBar should match snapshot 1`] = `
   >
     <a
       aria-current={null}
+      aria-label="Home"
       className="nav-button-container"
       data-testid="home-navlink"
       href="/home"
@@ -22,6 +23,7 @@ exports[`BotNavBar should match snapshot 1`] = `
     </a>
     <a
       aria-current={null}
+      aria-label="Camera"
       className="nav-button-container"
       data-testid="camera-navlink"
       href="/camera"
@@ -35,6 +37,7 @@ exports[`BotNavBar should match snapshot 1`] = `
     </a>
     <a
       aria-current={null}
+      aria-label="Create Event"
       className="nav-button-container"
       data-testid="create-event-navlink"
       href="/create-event"
@@ -48,6 +51,7 @@ exports[`BotNavBar should match snapshot 1`] = `
     </a>
     <a
       aria-current={null}
+      aria-label="Messages"
       className="nav-button-container"
       data-testid="messages-navlink"
       href="/messages"
@@ -61,6 +65,7 @@ exports[`BotNavBar should match snapshot 1`] = `
     </a>
     <a
       aria-current={null}
+      aria-label="Profile"
       className="nav-button-container"
       data-testid="profile-navlink"
       href="/profile"

--- a/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.scss
+++ b/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.scss
@@ -18,6 +18,6 @@
 
 .active {
   svg {
-    fill: $primary-color;
+    fill: $primary-color-lightened;
   }
 }

--- a/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.tsx
+++ b/apps/mull-ui/src/app/components/navigation/nav-buttons/nav-buttons.tsx
@@ -14,6 +14,7 @@ export const NavButtons = () => {
     <div className="nav-buttons-container">
       <NavLink
         to={ROUTES.HOME}
+        aria-label="Home"
         className="nav-button-container"
         activeClassName="active"
         data-testid="home-navlink"
@@ -23,6 +24,7 @@ export const NavButtons = () => {
       </NavLink>
       <NavLink
         to={ROUTES.CAMERA}
+        aria-label="Camera"
         className="nav-button-container"
         activeClassName="active"
         data-testid="camera-navlink"
@@ -31,6 +33,7 @@ export const NavButtons = () => {
       </NavLink>
       <NavLink
         to={ROUTES.CREATE_EVENT}
+        aria-label="Create Event"
         className="nav-button-container"
         activeClassName="active"
         data-testid="create-event-navlink"
@@ -39,6 +42,7 @@ export const NavButtons = () => {
       </NavLink>
       <NavLink
         to={ROUTES.MESSAGES}
+        aria-label="Messages"
         className="nav-button-container"
         activeClassName="active"
         data-testid="messages-navlink"
@@ -47,6 +51,7 @@ export const NavButtons = () => {
       </NavLink>
       <NavLink
         to={ROUTES.PROFILE.DISPLAY}
+        aria-label="Profile"
         className="nav-button-container"
         activeClassName="active"
         data-testid="profile-navlink"

--- a/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.scss
+++ b/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.scss
@@ -27,7 +27,7 @@
 }
 
 .subnavigation-link {
-  color: $inactive-button-color;
+  color: $inactive-text-color;
 }
 
 .active {

--- a/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.scss
+++ b/apps/mull-ui/src/app/components/navigation/sub-nav-bar/sub-nav-bar.scss
@@ -47,7 +47,7 @@
 
   .inner-cont {
     width: $page-container-width;
-    justify-content: space-between;
+    justify-content: space-around;
     padding: 0 1rem;
   }
 }

--- a/apps/mull-ui/src/app/components/navigation/top-nav-bar/__snapshots__/top-nav-bar.spec.tsx.snap
+++ b/apps/mull-ui/src/app/components/navigation/top-nav-bar/__snapshots__/top-nav-bar.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`TopNavBar should match snapshot 1`] = `
     >
       <a
         aria-current={null}
+        aria-label="Home"
         className="nav-button-container"
         data-testid="home-navlink"
         href="/home"
@@ -37,6 +38,7 @@ exports[`TopNavBar should match snapshot 1`] = `
       </a>
       <a
         aria-current={null}
+        aria-label="Camera"
         className="nav-button-container"
         data-testid="camera-navlink"
         href="/camera"
@@ -50,6 +52,7 @@ exports[`TopNavBar should match snapshot 1`] = `
       </a>
       <a
         aria-current={null}
+        aria-label="Create Event"
         className="nav-button-container"
         data-testid="create-event-navlink"
         href="/create-event"
@@ -63,6 +66,7 @@ exports[`TopNavBar should match snapshot 1`] = `
       </a>
       <a
         aria-current={null}
+        aria-label="Messages"
         className="nav-button-container"
         data-testid="messages-navlink"
         href="/messages"
@@ -76,6 +80,7 @@ exports[`TopNavBar should match snapshot 1`] = `
       </a>
       <a
         aria-current={null}
+        aria-label="Profile"
         className="nav-button-container"
         data-testid="profile-navlink"
         href="/profile"

--- a/apps/mull-ui/src/app/components/settings-button/settings-button.scss
+++ b/apps/mull-ui/src/app/components/settings-button/settings-button.scss
@@ -13,5 +13,5 @@
 .settings-icon {
   margin: 0.75rem;
   font-size: 1.25rem;
-  color: $primary-color;
+  color: $primary-color-lightened;
 }

--- a/apps/mull-ui/src/app/components/time-slider/time-slider.tsx
+++ b/apps/mull-ui/src/app/components/time-slider/time-slider.tsx
@@ -5,6 +5,7 @@ import { getStringTime } from '../../../utilities';
 import './time-slider.scss';
 
 export interface TimeSliderProps {
+  ariaLabel: string;
   label: string;
   reverse?: boolean;
   time: number;
@@ -14,6 +15,7 @@ export interface TimeSliderProps {
 }
 
 export const TimeSlider = ({
+  ariaLabel,
   label,
   reverse,
   time,
@@ -27,6 +29,7 @@ export const TimeSlider = ({
         {label} {getStringTime(time)}
       </div>
       <Slider
+        ariaLabelForHandle={ariaLabel}
         className="custom-slider-style"
         min={0}
         max={23.75}

--- a/apps/mull-ui/src/app/pages/create-event/create-event.scss
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.scss
@@ -18,7 +18,6 @@
 }
 
 .create-event-text {
-  color: $primary-color;
   font-size: 1rem;
   margin-bottom: 1rem;
 }

--- a/apps/mull-ui/src/app/pages/create-event/create-event.tsx
+++ b/apps/mull-ui/src/app/pages/create-event/create-event.tsx
@@ -245,6 +245,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
               }}
             />
             <TimeSlider
+              ariaLabel="Start time slider"
               label="Start"
               reverse={true}
               time={formik.values.startTime}
@@ -253,6 +254,7 @@ const CreateEventPage = ({ history }: CreateEventProps) => {
               errorMessage={formik.errors.startTime}
             />
             <TimeSlider
+              ariaLabel="End time slider"
               label="End"
               time={formik.values.endTime}
               onTimeChange={(time) => formik.setFieldValue('endTime', time)}

--- a/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.scss
+++ b/apps/mull-ui/src/app/pages/create-event/date-calendar/date-calendar.scss
@@ -8,12 +8,12 @@
 }
 
 .nice-dates-day:before {
-  background-color: $primary-color;
+  background-color: $primary-color-lightened;
   z-index: 1;
 }
 
 .nice-dates-day:after {
-  background-color: $primary-color;
+  background-color: $primary-color-lightened;
   z-index: 1;
 }
 

--- a/apps/mull-ui/src/app/pages/create-event/location-autocomplete/__snapshots__/location-autocomplete-modal.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/create-event/location-autocomplete/__snapshots__/location-autocomplete-modal.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`location autocomplete modal should match snapshot 1`] = `
     className="custom-text-input-sub-container"
   >
     <input
+      aria-label="location"
       className="custom-text-input input-border "
       data-testid="custom-text-input"
       id="location"

--- a/apps/mull-ui/src/app/pages/login/login.scss
+++ b/apps/mull-ui/src/app/pages/login/login.scss
@@ -73,7 +73,8 @@
 
   .login {
     font-weight: bold;
-    background-color: rgba($color: $primary-color, $alpha: 0.6);
+    background-color: $primary-color;
+    color: $background-color;
   }
 
   .twitter {

--- a/apps/mull-ui/src/app/pages/messages/event-messages/__snapshots__/event-message-list.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/messages/event-messages/__snapshots__/event-message-list.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`EventMessageList should match snapshot 1`] = `
       className="custom-text-input-sub-container"
     >
       <input
+        aria-label="searchField"
         className="custom-text-input input-border "
         data-testid="custom-text-input"
         id="searchField"

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/__snapshots__/edit-profile.spec.tsx.snap
@@ -93,6 +93,7 @@ exports[`EditProfile should match snapshot 1`] = `
         className="custom-text-input-sub-container"
       >
         <input
+          aria-label="displayName"
           className="custom-text-input input-border "
           data-testid="custom-text-input"
           id="displayName"

--- a/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.scss
+++ b/apps/mull-ui/src/app/pages/profile/edit-profile/edit-profile.scss
@@ -31,7 +31,7 @@
       border-radius: 20rem;
       padding: 0.35rem;
       border: 1px $primary-color solid;
-      color: $primary-color;
+      color: $primary-color-lightened;
       background-color: white;
     }
   }

--- a/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.scss
+++ b/apps/mull-ui/src/app/pages/profile/user-profile/user-profile.scss
@@ -6,7 +6,7 @@
 }
 
 .joined-date-container {
-  color: $inactive-button-color;
+  color: $inactive-text-color;
   margin: 0.5rem;
   text-align: center;
 }

--- a/apps/mull-ui/src/app/pages/register/register.scss
+++ b/apps/mull-ui/src/app/pages/register/register.scss
@@ -17,7 +17,7 @@
 .register-button {
   font-weight: bold;
   color: white;
-  background-color: rgba($color: $primary-color, $alpha: 0.6);
+  background-color: $primary-color;
   border: none;
   height: 2.8rem;
   cursor: pointer;

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -118,7 +118,7 @@ button,
 
 .empty-array-msg {
   text-align: center;
-  color: #777;
+  color: $inactive-text-color;
   &.text-left {
     text-align: left;
   }

--- a/apps/mull-ui/src/styles.scss
+++ b/apps/mull-ui/src/styles.scss
@@ -18,7 +18,7 @@
 }
 
 h1 {
-  color: $primary-color;
+  color: $primary-color-lightened;
   font-size: 1.25rem;
   font-weight: bold;
   margin: 0.25rem 0 1rem;

--- a/apps/mull-ui/src/variables.scss
+++ b/apps/mull-ui/src/variables.scss
@@ -4,9 +4,11 @@ $breakpoint-mobile: 50rem;
 
 // Colors
 $background-color: #ffffff;
-$primary-color: #27b09a;
+$primary-color: #1d8474;
+$primary-color-lightened: #2ba592;
 $error-color: #ff0000;
 $inactive-button-color: #bbbbbb;
+$inactive-text-color: #797676;
 $facebook: #4267b2;
 $google: #4285f4;
 $twitter: #1da1f2;


### PR DESCRIPTION
This PR works on #144 

I focused only on accessibility section of the lighthouse (lhouse) audit report. I cleared up the majority of the issues but there were still some here and there. This was as much as I could get done with my time today.

- Changed primary color to a darker green as suggested by lhouse report.
- Changed grey inactive color to a darker color as suggested by lhouse report.
- added aria-labels to make our app more screen reader friendly.
- update snapshots
- removed repeated html id resulting from event-card. html id must always be unique 
- centered the chat-input by removing the margin-top on the custom-text-input element.

**Testing**
I ran the app on my ip address, following the instructions in the readme. This allowed me to use the lighthouse tool available in the chrome debugger to generate a report. If you're not interested in running the tool you can just run the app locally and make sure everything still works/looks good.

**Notes**
Could someone please test the e2e for me, they take 10-15 minutes just to start for me.

**Pictures**

Discover page Before and After
![Discover-page](https://user-images.githubusercontent.com/25574985/114100003-ade3cf00-9891-11eb-9b33-effde57783fb.PNG)

![Discover-page-after](https://user-images.githubusercontent.com/25574985/114099988-a7edee00-9891-11eb-9327-7613b6816d1b.PNG)

Announcements Before and After
![Announcements](https://user-images.githubusercontent.com/25574985/114100073-c5bb5300-9891-11eb-9595-4910c52a7ed5.PNG)
![Announcements-after](https://user-images.githubusercontent.com/25574985/114100077-c7851680-9891-11eb-9c85-db15145a002d.PNG)

Create Event
![Create-Event](https://user-images.githubusercontent.com/25574985/114100123-d66bc900-9891-11eb-98eb-35c069d78585.PNG)
![Create-Event-after](https://user-images.githubusercontent.com/25574985/114100128-d8358c80-9891-11eb-895b-2fe07494b3ba.PNG)

